### PR TITLE
[Frontend] ナビゲーション構造の実装

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,20 +1,28 @@
-import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, Text, View } from 'react-native';
+import React from 'react'
+import { useColorScheme } from 'react-native'
+import { NavigationContainer } from '@react-navigation/native'
+import { PaperProvider } from 'react-native-paper'
+import { GestureHandlerRootView } from 'react-native-gesture-handler'
+import { SafeAreaProvider } from 'react-native-safe-area-context'
+import { StatusBar } from 'expo-status-bar'
+import { AutoplLightTheme, AutoplDarkTheme } from './src/theme'
+import { RootNavigator } from './src/navigation/RootNavigator'
 
 export default function App() {
-  return (
-    <View style={styles.container}>
-      <Text>Open up App.tsx to start working on your app!</Text>
-      <StatusBar style="auto" />
-    </View>
-  );
-}
+  const colorScheme = useColorScheme()
+  const isDark = colorScheme === 'dark'
+  const theme = isDark ? AutoplDarkTheme : AutoplLightTheme
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-});
+  return (
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <SafeAreaProvider>
+        <PaperProvider theme={theme}>
+          <NavigationContainer>
+            <StatusBar style={isDark ? 'light' : 'dark'} />
+            <RootNavigator />
+          </NavigationContainer>
+        </PaperProvider>
+      </SafeAreaProvider>
+    </GestureHandlerRootView>
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@react-native-community/netinfo": "^12.0.1",
         "@react-navigation/drawer": "^7.9.4",
         "@react-navigation/native": "^7.1.33",
+        "@react-navigation/native-stack": "^7.14.4",
         "expo": "~55.0.5",
         "expo-av": "^16.0.8",
         "expo-document-picker": "^55.0.8",
@@ -23,6 +24,8 @@
         "react-native-gesture-handler": "^2.30.0",
         "react-native-paper": "^5.15.0",
         "react-native-reanimated": "^4.2.2",
+        "react-native-safe-area-context": "^5.7.0",
+        "react-native-screens": "^4.24.0",
         "react-native-track-player": "^4.1.2",
         "zustand": "^5.0.11"
       },
@@ -2370,6 +2373,25 @@
       "peerDependencies": {
         "react": ">= 18.2.0",
         "react-native": "*"
+      }
+    },
+    "node_modules/@react-navigation/native-stack": {
+      "version": "7.14.4",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native-stack/-/native-stack-7.14.4.tgz",
+      "integrity": "sha512-HFEnM5Q7JY3FmmiolD/zvgY+9sxZAyVGPZJoz7BdTvJmi1VHOdplf24YiH45mqeitlGnaOlvNT55rH4abHJ5eA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-navigation/elements": "^2.9.10",
+        "color": "^4.2.3",
+        "sf-symbols-typescript": "^2.1.0",
+        "warn-once": "^0.1.1"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^7.1.33",
+        "react": ">= 18.2.0",
+        "react-native": "*",
+        "react-native-safe-area-context": ">= 4.0.0",
+        "react-native-screens": ">= 4.0.0"
       }
     },
     "node_modules/@react-navigation/routers": {
@@ -6983,6 +7005,15 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
     },
+    "node_modules/sf-symbols-typescript": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/sf-symbols-typescript/-/sf-symbols-typescript-2.2.0.tgz",
+      "integrity": "sha512-TPbeg0b7ylrswdGCji8FRGFAKuqbpQlLbL8SOle3j1iHSs5Ob5mhvMAxWN2UItOjgALAB5Zp3fmMfj8mbWvXKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -7527,6 +7558,7 @@
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@react-native-community/netinfo": "^12.0.1",
     "@react-navigation/drawer": "^7.9.4",
     "@react-navigation/native": "^7.1.33",
+    "@react-navigation/native-stack": "^7.14.4",
     "expo": "~55.0.5",
     "expo-av": "^16.0.8",
     "expo-document-picker": "^55.0.8",
@@ -24,6 +25,8 @@
     "react-native-gesture-handler": "^2.30.0",
     "react-native-paper": "^5.15.0",
     "react-native-reanimated": "^4.2.2",
+    "react-native-safe-area-context": "^5.7.0",
+    "react-native-screens": "^4.24.0",
     "react-native-track-player": "^4.1.2",
     "zustand": "^5.0.11"
   },

--- a/src/components/drawer/DrawerContent.tsx
+++ b/src/components/drawer/DrawerContent.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import { View, StyleSheet } from 'react-native'
+import { Text, useTheme } from 'react-native-paper'
+import {
+  DrawerContentScrollView,
+  DrawerContentComponentProps,
+} from '@react-navigation/drawer'
+
+/**
+ * ドロワー内コンテンツ（ファイル一覧）
+ * Issue #12 で本実装予定
+ */
+export const DrawerContent: React.FC<DrawerContentComponentProps> = (props) => {
+  const { colors } = useTheme()
+
+  return (
+    <DrawerContentScrollView
+      {...props}
+      style={[styles.container, { backgroundColor: colors.surface }]}
+    >
+      <View style={styles.placeholder}>
+        <Text
+          variant="bodySmall"
+          style={{ color: colors.onSurfaceVariant }}
+        >
+          ファイル一覧（Issue #12 で実装予定）
+        </Text>
+      </View>
+    </DrawerContentScrollView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  placeholder: {
+    padding: 16,
+    alignItems: 'center',
+  },
+})

--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import { createNativeStackNavigator } from '@react-navigation/native-stack'
+import { createDrawerNavigator } from '@react-navigation/drawer'
+import { useTheme } from 'react-native-paper'
+import { RootStackParamList, DrawerParamList } from './types'
+import { MainScreen } from '../screens/MainScreen'
+import { SettingsScreen } from '../screens/SettingsScreen'
+import { DrawerContent } from '../components/drawer/DrawerContent'
+
+const Stack = createNativeStackNavigator<RootStackParamList>()
+const Drawer = createDrawerNavigator<DrawerParamList>()
+
+/**
+ * ドロワーナビゲーター
+ * 左1/3スライドインのファイル一覧ドロワー
+ */
+const DrawerNavigator: React.FC = () => {
+  const { colors } = useTheme()
+
+  return (
+    <Drawer.Navigator
+      drawerContent={(props) => <DrawerContent {...props} />}
+      screenOptions={{
+        drawerStyle: {
+          width: '33%',
+          backgroundColor: colors.surface,
+        },
+        headerShown: false,
+        drawerType: 'slide',
+      }}
+    >
+      <Drawer.Screen name="Main" component={MainScreen} />
+    </Drawer.Navigator>
+  )
+}
+
+/**
+ * ルートナビゲーター
+ * DrawerNavigator（メイン） + Settings（スタック）
+ */
+export const RootNavigator: React.FC = () => {
+  return (
+    <Stack.Navigator screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="Drawer" component={DrawerNavigator} />
+      <Stack.Screen name="Settings" component={SettingsScreen} />
+    </Stack.Navigator>
+  )
+}

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -1,0 +1,14 @@
+/**
+ * ドロワーナビゲーターのスクリーン定義
+ */
+export type DrawerParamList = {
+  Main: undefined
+}
+
+/**
+ * スタックナビゲーターのスクリーン定義
+ */
+export type RootStackParamList = {
+  Drawer: undefined
+  Settings: undefined
+}

--- a/src/screens/MainScreen.tsx
+++ b/src/screens/MainScreen.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { View, StyleSheet } from 'react-native'
+import { Text, useTheme } from 'react-native-paper'
+import { DrawerNavigationProp } from '@react-navigation/drawer'
+import { DrawerParamList } from '../navigation/types'
+
+type Props = {
+  navigation: DrawerNavigationProp<DrawerParamList, 'Main'>
+}
+
+/**
+ * 再生画面（メイン画面）
+ * Issue #10 で本実装予定
+ */
+export const MainScreen: React.FC<Props> = () => {
+  const { colors } = useTheme()
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
+      <Text variant="headlineMedium" style={{ color: colors.onBackground }}>
+        Autopl
+      </Text>
+      <Text variant="bodyMedium" style={{ color: colors.onSurfaceVariant }}>
+        音楽ファイルをインポートして練習を開始してください
+      </Text>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+  },
+})

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { View, StyleSheet } from 'react-native'
+import { Text, useTheme, Appbar } from 'react-native-paper'
+import { NativeStackNavigationProp } from '@react-navigation/native-stack'
+import { RootStackParamList } from '../navigation/types'
+
+type Props = {
+  navigation: NativeStackNavigationProp<RootStackParamList, 'Settings'>
+}
+
+/**
+ * 設定画面
+ * Issue #13 で本実装予定
+ */
+export const SettingsScreen: React.FC<Props> = ({ navigation }) => {
+  const { colors } = useTheme()
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
+      <Appbar.Header>
+        <Appbar.BackAction
+          onPress={() => navigation.goBack()}
+          accessibilityLabel="戻る"
+        />
+        <Appbar.Content title="設定" />
+      </Appbar.Header>
+      <View style={styles.body}>
+        <Text variant="bodyMedium" style={{ color: colors.onSurfaceVariant }}>
+          設定画面（Issue #13 で実装予定）
+        </Text>
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  body: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+})

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,0 +1,41 @@
+import {
+  MD3LightTheme,
+  MD3DarkTheme,
+  MD3Theme,
+} from 'react-native-paper'
+
+/**
+ * Autopl Light Theme
+ * React Native Paper (Material Design 3) + Apple HIG 準拠
+ */
+export const AutoplLightTheme: MD3Theme = {
+  ...MD3LightTheme,
+  colors: {
+    ...MD3LightTheme.colors,
+    primary: '#1A73E8',
+    primaryContainer: '#D3E3FD',
+    onPrimaryContainer: '#0842A0',
+    secondary: '#5F6368',
+    background: '#F8F9FA',
+    surface: '#FFFFFF',
+    surfaceVariant: '#F1F3F4',
+  },
+}
+
+/**
+ * Autopl Dark Theme
+ * React Native Paper (Material Design 3) + Apple HIG 準拠
+ */
+export const AutoplDarkTheme: MD3Theme = {
+  ...MD3DarkTheme,
+  colors: {
+    ...MD3DarkTheme.colors,
+    primary: '#8AB4F8',
+    primaryContainer: '#0842A0',
+    onPrimaryContainer: '#D3E3FD',
+    secondary: '#9AA0A6',
+    background: '#1C1C1E',
+    surface: '#2C2C2E',
+    surfaceVariant: '#3A3A3C',
+  },
+}


### PR DESCRIPTION
## Summary
- DrawerNavigator（左1/3スライドイン）+ RootStackNavigator の2層構造を実装
- PaperProvider でテーマ管理（ダーク/ライト自動切替）
- 各画面はプレースホルダーとして実装（後続Issueで本実装）

## 追加ファイル
- `src/navigation/RootNavigator.tsx`: ナビゲーター定義
- `src/navigation/types.ts`: 画面パラメーター型定義
- `src/theme/index.ts`: カスタムライト/ダークテーマ
- `src/screens/MainScreen.tsx`: 再生画面（プレースホルダー）
- `src/screens/SettingsScreen.tsx`: 設定画面（プレースホルダー）
- `src/components/drawer/DrawerContent.tsx`: ドロワー（プレースホルダー）

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)