### PR TITLE
[Backend] 音楽ファイルインポート機能 (#7)

### DIFF
--- a/src/hooks/useFileImport.ts
+++ b/src/hooks/useFileImport.ts
@@ -1,0 +1,116 @@
+import { useState, useCallback } from 'react'
+import * as DocumentPicker from 'expo-document-picker'
+import { AudioFile } from '../types'
+import { useFileStore } from '../stores/fileStore'
+import { fileService } from '../services/fileService'
+import { validateImportFile, sanitizeFileName } from '../utils/validation'
+
+interface UseFileImportResult {
+  isImporting: boolean
+  importError: string | null
+  pickAndImportFile: () => Promise<void>
+  importFromUri: (uri: string, name: string, size: number) => Promise<void>
+  clearError: () => void
+}
+
+const generateUuid = (): string => {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(
+    /[xy]/g,
+    (character) => {
+      const random = (Math.random() * 16) | 0
+      const value = character === 'x' ? random : (random & 0x3) | 0x8
+      return value.toString(16)
+    }
+  )
+}
+
+const getExtension = (fileName: string): string => {
+  return fileName.split('.').pop()?.toLowerCase() ?? ''
+}
+
+export const useFileImport = (): UseFileImportResult => {
+  const [isImporting, setIsImporting] = useState(false)
+  const [importError, setImportError] = useState<string | null>(null)
+  const files = useFileStore((state) => state.files)
+  const addFile = useFileStore((state) => state.addFile)
+
+  const clearError = useCallback(() => {
+    setImportError(null)
+  }, [])
+
+  const importFromUri = useCallback(
+    async (uri: string, name: string, size: number) => {
+      setImportError(null)
+      setIsImporting(true)
+
+      try {
+        const sanitizedName = sanitizeFileName(name)
+        const validationError = validateImportFile(
+          { name: sanitizedName, size },
+          files
+        )
+
+        if (validationError) {
+          setImportError(validationError)
+          return
+        }
+
+        const fileId = generateUuid()
+        const extension = getExtension(sanitizedName)
+        const savedPath = await fileService.copyToAudioDir(
+          uri,
+          fileId,
+          extension
+        )
+
+        const audioFile: AudioFile = {
+          id: fileId,
+          name: sanitizedName,
+          path: savedPath,
+          duration: 0, // 後でTrackPlayerから取得
+          createdAt: Date.now(),
+        }
+
+        addFile(audioFile)
+      } catch (error) {
+        console.error('[useFileImport] importFromUri failed:', error)
+        setImportError('ファイルのインポートに失敗しました')
+      } finally {
+        setIsImporting(false)
+      }
+    },
+    [files, addFile]
+  )
+
+  const pickAndImportFile = useCallback(async () => {
+    setImportError(null)
+
+    try {
+      const result = await DocumentPicker.getDocumentAsync({
+        type: ['audio/mpeg', 'audio/wav', 'audio/x-m4a', 'audio/mp4'],
+      })
+
+      if (result.canceled) return
+
+      const pickedFile = result.assets[0]
+      if (!pickedFile) return
+
+      await importFromUri(
+        pickedFile.uri,
+        pickedFile.name,
+        pickedFile.size ?? 0
+      )
+    } catch (error) {
+      console.error('[useFileImport] pickAndImportFile failed:', error)
+      setImportError('ファイルの選択に失敗しました')
+    }
+  }, [importFromUri])
+
+  return {
+    isImporting,
+    importError,
+    pickAndImportFile,
+    importFromUri,
+    clearError,
+  }
+}

--- a/src/services/__tests__/fileService.test.ts
+++ b/src/services/__tests__/fileService.test.ts
@@ -1,0 +1,151 @@
+import { fileService } from '../fileService'
+
+// expo-file-system をモック
+const mockFileExists = jest.fn()
+const mockFileDelete = jest.fn()
+const mockFileCopy = jest.fn()
+const mockFileSize = 0
+const mockDirExists = jest.fn()
+const mockDirCreate = jest.fn()
+
+jest.mock('expo-file-system', () => {
+  const mockDocumentDir = { uri: '/mock/documents/' }
+  return {
+    Paths: {
+      document: mockDocumentDir,
+    },
+    File: jest.fn().mockImplementation((...args: unknown[]) => {
+      // URI を構築
+      const parts = args.map((arg) => {
+        if (typeof arg === 'string') return arg
+        if (arg && typeof arg === 'object' && 'uri' in arg)
+          return (arg as { uri: string }).uri
+        return ''
+      })
+      const uri = parts.join('/').replace(/\/+/g, '/')
+      return {
+        uri,
+        get exists() {
+          return mockFileExists()
+        },
+        delete: mockFileDelete,
+        copy: mockFileCopy,
+        get size() {
+          return mockFileSize
+        },
+      }
+    }),
+    Directory: jest.fn().mockImplementation((...args: unknown[]) => {
+      const parts = args.map((arg) => {
+        if (typeof arg === 'string') return arg
+        if (arg && typeof arg === 'object' && 'uri' in arg)
+          return (arg as { uri: string }).uri
+        return ''
+      })
+      const uri = parts.join('/').replace(/\/+/g, '/')
+      return {
+        uri,
+        get exists() {
+          return mockDirExists()
+        },
+        create: mockDirCreate,
+      }
+    }),
+  }
+})
+
+describe('fileService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('getAudioDirPath', () => {
+    it('audio ディレクトリのURIを返す', () => {
+      const path = fileService.getAudioDirPath()
+      expect(path).toContain('audio')
+    })
+  })
+
+  describe('ensureAudioDir', () => {
+    it('ディレクトリが存在しない場合は作成する', async () => {
+      mockDirExists.mockReturnValue(false)
+
+      await fileService.ensureAudioDir()
+
+      expect(mockDirCreate).toHaveBeenCalled()
+    })
+
+    it('ディレクトリが存在する場合は作成しない', async () => {
+      mockDirExists.mockReturnValue(true)
+
+      await fileService.ensureAudioDir()
+
+      expect(mockDirCreate).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('copyToAudioDir', () => {
+    it('ファイルをaudioディレクトリにコピーしてURIを返す', async () => {
+      mockDirExists.mockReturnValue(true)
+
+      const result = await fileService.copyToAudioDir(
+        '/source/song.mp3',
+        'uuid-1',
+        'mp3'
+      )
+
+      expect(result).toContain('uuid-1.mp3')
+      expect(mockFileCopy).toHaveBeenCalled()
+    })
+  })
+
+  describe('deleteFile', () => {
+    it('ファイルが存在する場合は削除する', async () => {
+      mockFileExists.mockReturnValue(true)
+
+      await fileService.deleteFile('/mock/documents/audio/uuid-1.mp3')
+
+      expect(mockFileDelete).toHaveBeenCalled()
+    })
+
+    it('ファイルが存在しない場合は削除しない', async () => {
+      mockFileExists.mockReturnValue(false)
+
+      await fileService.deleteFile('/mock/documents/audio/uuid-1.mp3')
+
+      expect(mockFileDelete).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('fileExists', () => {
+    it('ファイルが存在する場合はtrueを返す', () => {
+      mockFileExists.mockReturnValue(true)
+
+      const result = fileService.fileExists('/mock/documents/audio/uuid-1.mp3')
+      expect(result).toBe(true)
+    })
+
+    it('ファイルが存在しない場合はfalseを返す', () => {
+      mockFileExists.mockReturnValue(false)
+
+      const result = fileService.fileExists('/mock/documents/audio/uuid-1.mp3')
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('getFileSize', () => {
+    it('ファイルが存在する場合はサイズを返す', () => {
+      mockFileExists.mockReturnValue(true)
+
+      const size = fileService.getFileSize('/mock/documents/audio/uuid-1.mp3')
+      expect(size).toBe(0)
+    })
+
+    it('ファイルが存在しない場合はnullを返す', () => {
+      mockFileExists.mockReturnValue(false)
+
+      const size = fileService.getFileSize('/mock/documents/audio/uuid-1.mp3')
+      expect(size).toBeNull()
+    })
+  })
+})

--- a/src/services/__tests__/storageService.test.ts
+++ b/src/services/__tests__/storageService.test.ts
@@ -1,0 +1,162 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { storageService } from '../storageService'
+import { AudioFile, Settings } from '../../types'
+import { STORAGE_KEYS, DEFAULT_SETTINGS } from '../../constants/defaults'
+
+describe('storageService', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear()
+  })
+
+  // ── ファイルメタデータ ──
+
+  describe('loadFiles', () => {
+    it('データがない場合は空配列を返す', async () => {
+      const files = await storageService.loadFiles()
+      expect(files).toEqual([])
+    })
+
+    it('保存済みのファイル一覧を返す', async () => {
+      const mockFiles: AudioFile[] = [
+        {
+          id: 'uuid-1',
+          name: 'song1.mp3',
+          path: '/audio/uuid-1.mp3',
+          duration: 240,
+          createdAt: Date.now(),
+        },
+      ]
+      await AsyncStorage.setItem(
+        STORAGE_KEYS.FILES,
+        JSON.stringify(mockFiles)
+      )
+
+      const files = await storageService.loadFiles()
+      expect(files).toEqual(mockFiles)
+    })
+  })
+
+  describe('saveFiles', () => {
+    it('ファイル一覧を保存できる', async () => {
+      const mockFiles: AudioFile[] = [
+        {
+          id: 'uuid-1',
+          name: 'song1.mp3',
+          path: '/audio/uuid-1.mp3',
+          duration: 240,
+          createdAt: Date.now(),
+        },
+      ]
+      await storageService.saveFiles(mockFiles)
+
+      const stored = await AsyncStorage.getItem(STORAGE_KEYS.FILES)
+      expect(JSON.parse(stored!)).toEqual(mockFiles)
+    })
+  })
+
+  // ── 選択中ファイルID ──
+
+  describe('loadSelectedFileId', () => {
+    it('データがない場合はnullを返す', async () => {
+      const fileId = await storageService.loadSelectedFileId()
+      expect(fileId).toBeNull()
+    })
+
+    it('保存済みのファイルIDを返す', async () => {
+      await AsyncStorage.setItem(STORAGE_KEYS.SELECTED_FILE_ID, 'uuid-1')
+
+      const fileId = await storageService.loadSelectedFileId()
+      expect(fileId).toBe('uuid-1')
+    })
+  })
+
+  describe('saveSelectedFileId', () => {
+    it('ファイルIDを保存できる', async () => {
+      await storageService.saveSelectedFileId('uuid-1')
+
+      const stored = await AsyncStorage.getItem(STORAGE_KEYS.SELECTED_FILE_ID)
+      expect(stored).toBe('uuid-1')
+    })
+
+    it('nullを渡すとキーが削除される', async () => {
+      await AsyncStorage.setItem(STORAGE_KEYS.SELECTED_FILE_ID, 'uuid-1')
+      await storageService.saveSelectedFileId(null)
+
+      const stored = await AsyncStorage.getItem(STORAGE_KEYS.SELECTED_FILE_ID)
+      expect(stored).toBeNull()
+    })
+  })
+
+  // ── 設定 ──
+
+  describe('loadSettings', () => {
+    it('データがない場合はデフォルト設定を返す', async () => {
+      const settings = await storageService.loadSettings()
+      expect(settings).toEqual(DEFAULT_SETTINGS)
+    })
+
+    it('保存済みの設定を返す', async () => {
+      const customSettings: Settings = {
+        ...DEFAULT_SETTINGS,
+        wakeWord: 'スタート',
+        timeoutSeconds: 20,
+      }
+      await AsyncStorage.setItem(
+        STORAGE_KEYS.SETTINGS,
+        JSON.stringify(customSettings)
+      )
+
+      const settings = await storageService.loadSettings()
+      expect(settings.wakeWord).toBe('スタート')
+      expect(settings.timeoutSeconds).toBe(20)
+    })
+
+    it('部分的な設定でもデフォルトとマージされる', async () => {
+      await AsyncStorage.setItem(
+        STORAGE_KEYS.SETTINGS,
+        JSON.stringify({ wakeWord: 'テスト' })
+      )
+
+      const settings = await storageService.loadSettings()
+      expect(settings.wakeWord).toBe('テスト')
+      expect(settings.commands).toEqual(DEFAULT_SETTINGS.commands)
+      expect(settings.timeoutSeconds).toBe(DEFAULT_SETTINGS.timeoutSeconds)
+    })
+  })
+
+  describe('saveSettings', () => {
+    it('設定を保存できる', async () => {
+      const settings: Settings = {
+        ...DEFAULT_SETTINGS,
+        soundEnabled: false,
+      }
+      await storageService.saveSettings(settings)
+
+      const stored = await AsyncStorage.getItem(STORAGE_KEYS.SETTINGS)
+      expect(JSON.parse(stored!).soundEnabled).toBe(false)
+    })
+  })
+
+  // ── 全データクリア ──
+
+  describe('clearAll', () => {
+    it('全てのキーが削除される', async () => {
+      await AsyncStorage.setItem(STORAGE_KEYS.FILES, '[]')
+      await AsyncStorage.setItem(STORAGE_KEYS.SELECTED_FILE_ID, 'uuid-1')
+      await AsyncStorage.setItem(
+        STORAGE_KEYS.SETTINGS,
+        JSON.stringify(DEFAULT_SETTINGS)
+      )
+
+      await storageService.clearAll()
+
+      const files = await AsyncStorage.getItem(STORAGE_KEYS.FILES)
+      const fileId = await AsyncStorage.getItem(STORAGE_KEYS.SELECTED_FILE_ID)
+      const settings = await AsyncStorage.getItem(STORAGE_KEYS.SETTINGS)
+
+      expect(files).toBeNull()
+      expect(fileId).toBeNull()
+      expect(settings).toBeNull()
+    })
+  })
+})

--- a/src/services/fileService.ts
+++ b/src/services/fileService.ts
@@ -1,0 +1,105 @@
+import { Paths, File, Directory } from 'expo-file-system'
+
+const AUDIO_DIR_NAME = 'audio'
+
+/**
+ * expo-file-system ラッパーサービス
+ * サンドボックス内のファイルコピー・削除を担当
+ */
+export const fileService = {
+  /**
+   * audio ディレクトリを取得する（存在しなければ作成）
+   */
+  getAudioDir(): Directory {
+    return new Directory(Paths.document, AUDIO_DIR_NAME)
+  },
+
+  /**
+   * audio ディレクトリが存在しなければ作成する
+   */
+  async ensureAudioDir(): Promise<void> {
+    try {
+      const audioDir = fileService.getAudioDir()
+      if (!audioDir.exists) {
+        audioDir.create()
+      }
+    } catch (error) {
+      console.error('[FileService] ensureAudioDir failed:', error)
+      throw error
+    }
+  },
+
+  /**
+   * ファイルをサンドボックス内の audio ディレクトリにコピーする
+   * @returns コピー先のファイルパス（URI）
+   */
+  async copyToAudioDir(
+    sourceUri: string,
+    fileId: string,
+    extension: string
+  ): Promise<string> {
+    try {
+      await fileService.ensureAudioDir()
+      const audioDir = fileService.getAudioDir()
+      const sourceFile = new File(sourceUri)
+      const destinationFile = new File(audioDir, `${fileId}.${extension}`)
+      sourceFile.copy(destinationFile)
+      return destinationFile.uri
+    } catch (error) {
+      console.error('[FileService] copyToAudioDir failed:', error)
+      throw error
+    }
+  },
+
+  /**
+   * サンドボックス内のファイルを削除する
+   */
+  async deleteFile(filePath: string): Promise<void> {
+    try {
+      const file = new File(filePath)
+      if (file.exists) {
+        file.delete()
+      }
+    } catch (error) {
+      console.error('[FileService] deleteFile failed:', error)
+      throw error
+    }
+  },
+
+  /**
+   * ファイルが存在するか確認する
+   */
+  fileExists(filePath: string): boolean {
+    try {
+      const file = new File(filePath)
+      return file.exists
+    } catch (error) {
+      console.error('[FileService] fileExists failed:', error)
+      return false
+    }
+  },
+
+  /**
+   * ファイルサイズを取得する（バイト単位）
+   * ファイルが存在しない場合は null を返す
+   */
+  getFileSize(filePath: string): number | null {
+    try {
+      const file = new File(filePath)
+      if (file.exists) {
+        return file.size ?? null
+      }
+      return null
+    } catch (error) {
+      console.error('[FileService] getFileSize failed:', error)
+      return null
+    }
+  },
+
+  /**
+   * audio ディレクトリのパスを返す
+   */
+  getAudioDirPath(): string {
+    return fileService.getAudioDir().uri
+  },
+}

--- a/src/services/storageService.ts
+++ b/src/services/storageService.ts
@@ -1,0 +1,93 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { AudioFile, Settings } from '../types'
+import { STORAGE_KEYS, DEFAULT_SETTINGS } from '../constants/defaults'
+
+/**
+ * AsyncStorage ラッパーサービス
+ * 設定値・ファイルメタデータの永続化を担当
+ */
+export const storageService = {
+  // ── ファイルメタデータ ──
+
+  async loadFiles(): Promise<AudioFile[]> {
+    try {
+      const json = await AsyncStorage.getItem(STORAGE_KEYS.FILES)
+      if (json === null) return []
+      return JSON.parse(json) as AudioFile[]
+    } catch (error) {
+      console.error('[StorageService] loadFiles failed:', error)
+      return []
+    }
+  },
+
+  async saveFiles(files: AudioFile[]): Promise<void> {
+    try {
+      await AsyncStorage.setItem(STORAGE_KEYS.FILES, JSON.stringify(files))
+    } catch (error) {
+      console.error('[StorageService] saveFiles failed:', error)
+    }
+  },
+
+  // ── 選択中ファイルID ──
+
+  async loadSelectedFileId(): Promise<string | null> {
+    try {
+      return await AsyncStorage.getItem(STORAGE_KEYS.SELECTED_FILE_ID)
+    } catch (error) {
+      console.error('[StorageService] loadSelectedFileId failed:', error)
+      return null
+    }
+  },
+
+  async saveSelectedFileId(fileId: string | null): Promise<void> {
+    try {
+      if (fileId === null) {
+        await AsyncStorage.removeItem(STORAGE_KEYS.SELECTED_FILE_ID)
+      } else {
+        await AsyncStorage.setItem(STORAGE_KEYS.SELECTED_FILE_ID, fileId)
+      }
+    } catch (error) {
+      console.error('[StorageService] saveSelectedFileId failed:', error)
+    }
+  },
+
+  // ── 設定 ──
+
+  async loadSettings(): Promise<Settings> {
+    try {
+      const json = await AsyncStorage.getItem(STORAGE_KEYS.SETTINGS)
+      if (json === null) return DEFAULT_SETTINGS
+      return { ...DEFAULT_SETTINGS, ...JSON.parse(json) } as Settings
+    } catch (error) {
+      console.error('[StorageService] loadSettings failed:', error)
+      return DEFAULT_SETTINGS
+    }
+  },
+
+  async saveSettings(settings: Settings): Promise<void> {
+    try {
+      await AsyncStorage.setItem(
+        STORAGE_KEYS.SETTINGS,
+        JSON.stringify(settings)
+      )
+    } catch (error) {
+      console.error('[StorageService] saveSettings failed:', error)
+    }
+  },
+
+  // ── 全データクリア ──
+
+  async clearAll(): Promise<void> {
+    try {
+      const keys = [
+        STORAGE_KEYS.FILES,
+        STORAGE_KEYS.SELECTED_FILE_ID,
+        STORAGE_KEYS.SETTINGS,
+        STORAGE_KEYS.ONBOARDING_DONE,
+      ]
+      await Promise.all(keys.map((key) => AsyncStorage.removeItem(key)))
+    } catch (error) {
+      console.error('[StorageService] clearAll failed:', error)
+    }
+  },
+}

--- a/src/utils/__tests__/validation.test.ts
+++ b/src/utils/__tests__/validation.test.ts
@@ -1,0 +1,212 @@
+import {
+  validateWakeWord,
+  validateCommandWord,
+  validateTimeout,
+  validateImportFile,
+  sanitizeFileName,
+} from '../validation'
+import { AudioFile } from '../../types'
+
+describe('validateWakeWord', () => {
+  it('空文字のときエラーメッセージを返す', () => {
+    expect(validateWakeWord('')).toBe('ウェイクワードを入力してください')
+  })
+
+  it('空白のみのときエラーメッセージを返す', () => {
+    expect(validateWakeWord('   ')).toBe('ウェイクワードを入力してください')
+  })
+
+  it('1文字のとき文字数エラーを返す', () => {
+    expect(validateWakeWord('あ')).toBe(
+      'ウェイクワードは2〜20文字で入力してください'
+    )
+  })
+
+  it('21文字のとき文字数エラーを返す', () => {
+    expect(validateWakeWord('あ'.repeat(21))).toBe(
+      'ウェイクワードは2〜20文字で入力してください'
+    )
+  })
+
+  it('2文字のとき正常', () => {
+    expect(validateWakeWord('はい')).toBeNull()
+  })
+
+  it('20文字のとき正常', () => {
+    expect(validateWakeWord('あ'.repeat(20))).toBeNull()
+  })
+
+  it('記号を含むときエラーを返す', () => {
+    expect(validateWakeWord('はい!')).toBe('記号は使用できません')
+  })
+
+  it('日本語・英数字・スペースは正常', () => {
+    expect(validateWakeWord('はい 行きます GO')).toBeNull()
+  })
+})
+
+describe('validateCommandWord', () => {
+  it('空文字のときエラーを返す', () => {
+    expect(validateCommandWord('', [], 'ウェイク')).toBe(
+      'コマンド語を入力してください'
+    )
+  })
+
+  it('21文字のとき文字数エラーを返す', () => {
+    expect(validateCommandWord('あ'.repeat(21), [], 'ウェイク')).toBe(
+      'コマンド語は1〜20文字で入力してください'
+    )
+  })
+
+  it('記号を含むときエラーを返す', () => {
+    expect(validateCommandWord('再生!', [], 'ウェイク')).toBe(
+      '記号は使用できません'
+    )
+  })
+
+  it('他のコマンドと重複するときエラーを返す', () => {
+    expect(validateCommandWord('再生', ['再生', '停止'], 'ウェイク')).toBe(
+      'このコマンド語はすでに使われています'
+    )
+  })
+
+  it('ウェイクワードと重複するときエラーを返す', () => {
+    expect(validateCommandWord('ウェイク', [], 'ウェイク')).toBe(
+      'このコマンド語はすでに使われています'
+    )
+  })
+
+  it('1文字のコマンド語は正常', () => {
+    expect(validateCommandWord('次', [], 'ウェイク')).toBeNull()
+  })
+
+  it('重複なしのときは正常', () => {
+    expect(validateCommandWord('再生', ['停止', '次'], 'ウェイク')).toBeNull()
+  })
+})
+
+describe('validateTimeout', () => {
+  it('整数でないときエラーを返す', () => {
+    expect(validateTimeout('abc')).toBe(
+      'タイムアウトは3〜30秒の整数で入力してください'
+    )
+  })
+
+  it('小数のときエラーを返す', () => {
+    expect(validateTimeout('5.5')).toBe(
+      'タイムアウトは3〜30秒の整数で入力してください'
+    )
+  })
+
+  it('2秒のとき範囲エラーを返す', () => {
+    expect(validateTimeout('2')).toBe(
+      'タイムアウトは3〜30秒の整数で入力してください'
+    )
+  })
+
+  it('31秒のとき範囲エラーを返す', () => {
+    expect(validateTimeout('31')).toBe(
+      'タイムアウトは3〜30秒の整数で入力してください'
+    )
+  })
+
+  it('3秒のとき正常', () => {
+    expect(validateTimeout('3')).toBeNull()
+  })
+
+  it('30秒のとき正常', () => {
+    expect(validateTimeout('30')).toBeNull()
+  })
+
+  it('10秒のとき正常', () => {
+    expect(validateTimeout('10')).toBeNull()
+  })
+})
+
+describe('validateImportFile', () => {
+  const existingFiles: AudioFile[] = [
+    {
+      id: 'uuid-1',
+      name: 'existing.mp3',
+      path: '/audio/uuid-1.mp3',
+      duration: 240,
+      createdAt: Date.now(),
+    },
+  ]
+
+  it('mp3ファイルは正常', () => {
+    expect(
+      validateImportFile({ name: 'song.mp3', size: 1024 }, [])
+    ).toBeNull()
+  })
+
+  it('wavファイルは正常', () => {
+    expect(
+      validateImportFile({ name: 'song.wav', size: 1024 }, [])
+    ).toBeNull()
+  })
+
+  it('m4aファイルは正常', () => {
+    expect(
+      validateImportFile({ name: 'song.m4a', size: 1024 }, [])
+    ).toBeNull()
+  })
+
+  it('非対応形式のときエラーを返す', () => {
+    expect(validateImportFile({ name: 'song.ogg', size: 1024 }, [])).toBe(
+      'mp3・wav・m4a 形式のファイルのみインポートできます'
+    )
+  })
+
+  it('拡張子がないときエラーを返す', () => {
+    expect(validateImportFile({ name: 'song', size: 1024 }, [])).toBe(
+      'mp3・wav・m4a 形式のファイルのみインポートできます'
+    )
+  })
+
+  it('500MBを超えるときエラーを返す', () => {
+    const overSize = 500 * 1024 * 1024 + 1
+    expect(validateImportFile({ name: 'big.mp3', size: overSize }, [])).toBe(
+      'ファイルサイズが大きすぎます（上限500MB）'
+    )
+  })
+
+  it('500MBちょうどは正常', () => {
+    const exactSize = 500 * 1024 * 1024
+    expect(
+      validateImportFile({ name: 'exact.mp3', size: exactSize }, [])
+    ).toBeNull()
+  })
+
+  it('同名ファイルが存在するときエラーを返す', () => {
+    expect(
+      validateImportFile(
+        { name: 'existing.mp3', size: 1024 },
+        existingFiles
+      )
+    ).toBe('同名のファイルが既にインポートされています')
+  })
+
+  it('同名ファイルが存在しないときは正常', () => {
+    expect(
+      validateImportFile({ name: 'new-song.mp3', size: 1024 }, existingFiles)
+    ).toBeNull()
+  })
+})
+
+describe('sanitizeFileName', () => {
+  it('空文字のとき空文字を返す', () => {
+    expect(sanitizeFileName('')).toBe('')
+  })
+
+  it('100文字以内のときそのまま返す', () => {
+    const name = 'short-name.mp3'
+    expect(sanitizeFileName(name)).toBe(name)
+  })
+
+  it('100文字を超えるとき先頭100文字に切り詰める', () => {
+    const longName = 'a'.repeat(110) + '.mp3'
+    expect(sanitizeFileName(longName)).toHaveLength(100)
+    expect(sanitizeFileName(longName)).toBe('a'.repeat(100))
+  })
+})

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,71 @@
+import { AudioFile } from '../types'
+import { FILE_IMPORT_CONSTRAINTS } from '../constants/defaults'
+
+/**
+ * ウェイクワードのバリデーション
+ */
+export const validateWakeWord = (value: string): string | null => {
+  const trimmed = value.trim()
+  if (trimmed.length === 0) return 'ウェイクワードを入力してください'
+  if (trimmed.length < 2 || trimmed.length > 20)
+    return 'ウェイクワードは2〜20文字で入力してください'
+  if (/[!-/:-@[-`{-~]/.test(trimmed)) return '記号は使用できません'
+  return null
+}
+
+/**
+ * コマンド語のバリデーション
+ */
+export const validateCommandWord = (
+  value: string,
+  otherValues: string[],
+  wakeWord: string
+): string | null => {
+  const trimmed = value.trim()
+  if (trimmed.length === 0) return 'コマンド語を入力してください'
+  if (trimmed.length < 1 || trimmed.length > 20)
+    return 'コマンド語は1〜20文字で入力してください'
+  if (/[!-/:-@[-`{-~]/.test(trimmed)) return '記号は使用できません'
+  if (otherValues.some((other) => other.trim() === trimmed))
+    return 'このコマンド語はすでに使われています'
+  if (wakeWord.trim() === trimmed)
+    return 'このコマンド語はすでに使われています'
+  return null
+}
+
+/**
+ * タイムアウト秒数のバリデーション
+ */
+export const validateTimeout = (value: string): string | null => {
+  const num = Number(value)
+  if (!Number.isInteger(num) || value.includes('.'))
+    return 'タイムアウトは3〜30秒の整数で入力してください'
+  if (num < 3 || num > 30)
+    return 'タイムアウトは3〜30秒の整数で入力してください'
+  return null
+}
+
+/**
+ * インポートファイルのバリデーション
+ */
+export const validateImportFile = (
+  file: { name: string; size: number },
+  existingFiles: AudioFile[]
+): string | null => {
+  const extension = `.${file.name.split('.').pop()?.toLowerCase()}`
+  if (!FILE_IMPORT_CONSTRAINTS.ALLOWED_EXTENSIONS.includes(extension))
+    return 'mp3・wav・m4a 形式のファイルのみインポートできます'
+  if (file.size > FILE_IMPORT_CONSTRAINTS.MAX_FILE_SIZE_MB * 1024 * 1024)
+    return 'ファイルサイズが大きすぎます（上限500MB）'
+  if (existingFiles.some((existingFile) => existingFile.name === file.name))
+    return '同名のファイルが既にインポートされています'
+  return null
+}
+
+/**
+ * ファイル名をサニタイズする（100文字制限）
+ */
+export const sanitizeFileName = (name: string): string => {
+  if (!name) return ''
+  return name.length > 100 ? name.substring(0, 100) : name
+}


### PR DESCRIPTION
## Summary
- バリデーション関数（ウェイクワード・コマンド語・タイムアウト・ファイルインポート・ファイル名サニタイズ）を実装
- `useFileImport` フックでDocumentPicker経由のインポートとShare Extension用の `importFromUri` を実装
- 全34バリデーションテストがパス

## Changes
- `src/utils/validation.ts`: 5つのバリデーション関数
- `src/utils/__tests__/validation.test.ts`: 34テスト
- `src/hooks/useFileImport.ts`: ファイルインポートフック（picker + URI直接インポート）

## Test plan
- [x] `npx jest src/utils/__tests__/validation.test.ts` で全34テストがパス
- [x] `npx tsc --noEmit` で型エラーなし
- [ ] 実機でDocumentPickerからのインポート動作確認

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)