### PR TITLE
[Frontend] 聞き取り中モーダルUI実装 (#12)

### DIFF
--- a/src/components/player/ListeningIndicator.tsx
+++ b/src/components/player/ListeningIndicator.tsx
@@ -1,0 +1,162 @@
+import React, { useEffect, useRef } from 'react'
+import { View, StyleSheet, Animated, Easing } from 'react-native'
+import { Modal, Portal, Text, useTheme } from 'react-native-paper'
+import { VoiceRecognitionState } from '../../types'
+import { useVoiceStore } from '../../stores/voiceStore'
+
+const CIRCLE_COUNT = 3
+const ANIMATION_DURATION = 1200
+
+interface ListeningIndicatorProps {
+  visible: boolean
+}
+
+export const ListeningIndicator: React.FC<ListeningIndicatorProps> = ({
+  visible,
+}) => {
+  const { colors } = useTheme()
+  const recognitionState = useVoiceStore((state) => state.recognitionState)
+
+  const pulseAnimations = useRef(
+    Array.from({ length: CIRCLE_COUNT }, () => new Animated.Value(0))
+  ).current
+
+  useEffect(() => {
+    if (!visible) return
+
+    const animations = pulseAnimations.map((anim, index) =>
+      Animated.loop(
+        Animated.sequence([
+          Animated.delay(index * (ANIMATION_DURATION / CIRCLE_COUNT)),
+          Animated.timing(anim, {
+            toValue: 1,
+            duration: ANIMATION_DURATION,
+            easing: Easing.out(Easing.ease),
+            useNativeDriver: true,
+          }),
+          Animated.timing(anim, {
+            toValue: 0,
+            duration: 0,
+            useNativeDriver: true,
+          }),
+        ])
+      )
+    )
+
+    animations.forEach((animation) => animation.start())
+
+    return () => {
+      animations.forEach((animation) => animation.stop())
+      pulseAnimations.forEach((anim) => anim.setValue(0))
+    }
+  }, [visible, pulseAnimations])
+
+  const isListening =
+    recognitionState === VoiceRecognitionState.LISTENING_FOR_COMMAND
+  const isProcessing = recognitionState === VoiceRecognitionState.PROCESSING
+
+  const statusText = isProcessing ? '処理中...' : '聞き取り中...'
+
+  return (
+    <Portal>
+      <Modal
+        visible={visible}
+        dismissable={false}
+        contentContainerStyle={styles.modalContainer}
+      >
+        <View
+          style={[
+            styles.indicatorContainer,
+            { backgroundColor: colors.surface + 'E6' },
+          ]}
+        >
+          <View style={styles.circleContainer}>
+            {pulseAnimations.map((anim, index) => {
+              const scale = anim.interpolate({
+                inputRange: [0, 1],
+                outputRange: [0.6, 1.4],
+              })
+              const opacity = anim.interpolate({
+                inputRange: [0, 0.5, 1],
+                outputRange: [0.8, 0.4, 0],
+              })
+
+              return (
+                <Animated.View
+                  key={index}
+                  style={[
+                    styles.pulseCircle,
+                    {
+                      backgroundColor: colors.primary,
+                      transform: [{ scale }],
+                      opacity,
+                    },
+                  ]}
+                />
+              )
+            })}
+            <View
+              style={[
+                styles.centerCircle,
+                {
+                  backgroundColor: isListening || isProcessing
+                    ? colors.primary
+                    : colors.surfaceVariant,
+                },
+              ]}
+            />
+          </View>
+
+          <Text
+            variant="titleMedium"
+            style={[styles.statusText, { color: colors.onSurface }]}
+            accessibilityLabel={statusText}
+            accessibilityRole="text"
+          >
+            {statusText}
+          </Text>
+        </View>
+      </Modal>
+    </Portal>
+  )
+}
+
+const INDICATOR_SIZE = 160
+const CENTER_CIRCLE_SIZE = 48
+const PULSE_CIRCLE_SIZE = 80
+
+const styles = StyleSheet.create({
+  modalContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  indicatorContainer: {
+    width: INDICATOR_SIZE,
+    borderRadius: 24,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 28,
+    paddingHorizontal: 20,
+  },
+  circleContainer: {
+    width: PULSE_CIRCLE_SIZE * 1.8,
+    height: PULSE_CIRCLE_SIZE * 1.8,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 16,
+  },
+  pulseCircle: {
+    position: 'absolute',
+    width: PULSE_CIRCLE_SIZE,
+    height: PULSE_CIRCLE_SIZE,
+    borderRadius: PULSE_CIRCLE_SIZE / 2,
+  },
+  centerCircle: {
+    width: CENTER_CIRCLE_SIZE,
+    height: CENTER_CIRCLE_SIZE,
+    borderRadius: CENTER_CIRCLE_SIZE / 2,
+  },
+  statusText: {
+    textAlign: 'center',
+  },
+})

--- a/src/screens/MainScreen.tsx
+++ b/src/screens/MainScreen.tsx
@@ -1,6 +1,6 @@
-import React, { useState, useCallback } from 'react'
+import React, { useState, useCallback, useEffect } from 'react'
 import { View, StyleSheet } from 'react-native'
-import { Appbar, Text, useTheme } from 'react-native-paper'
+import { Appbar, Snackbar, Text, useTheme } from 'react-native-paper'
 import { DrawerNavigationProp } from '@react-navigation/drawer'
 import { useNavigation } from '@react-navigation/native'
 import { NativeStackNavigationProp } from '@react-navigation/native-stack'
@@ -8,8 +8,10 @@ import { DrawerParamList, RootStackParamList } from '../navigation/types'
 import { SegmentedProgressBar } from '../components/player/SegmentedProgressBar'
 import { PlayerControls } from '../components/player/PlayerControls'
 import { PlaybackRateSelector } from '../components/player/PlaybackRateSelector'
+import { ListeningIndicator } from '../components/player/ListeningIndicator'
 import { useAudioPlayer } from '../hooks/useAudioPlayer'
-import { PlaybackRate } from '../types'
+import { useVoiceStore } from '../stores/voiceStore'
+import { PlaybackRate, VoiceRecognitionState } from '../types'
 
 type Props = {
   navigation: DrawerNavigationProp<DrawerParamList, 'Main'>
@@ -22,6 +24,35 @@ export const MainScreen: React.FC<Props> = ({ navigation }) => {
   const stackNavigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList>>()
   const [isRateSelectorVisible, setIsRateSelectorVisible] = useState(false)
+  const [isFailureSnackbarVisible, setIsFailureSnackbarVisible] =
+    useState(false)
+
+  const recognitionState = useVoiceStore((state) => state.recognitionState)
+  const previousRecognitionStateRef = React.useRef(recognitionState)
+
+  const isListeningModalVisible =
+    recognitionState === VoiceRecognitionState.LISTENING_FOR_COMMAND ||
+    recognitionState === VoiceRecognitionState.PROCESSING
+
+  useEffect(() => {
+    const previousState = previousRecognitionStateRef.current
+    previousRecognitionStateRef.current = recognitionState
+
+    const wasListeningOrProcessing =
+      previousState === VoiceRecognitionState.LISTENING_FOR_COMMAND ||
+      previousState === VoiceRecognitionState.PROCESSING
+
+    const isNowIdle =
+      recognitionState === VoiceRecognitionState.IDLE ||
+      recognitionState === VoiceRecognitionState.LISTENING_FOR_WAKEWORD
+
+    if (wasListeningOrProcessing && isNowIdle) {
+      const lastText = useVoiceStore.getState().lastRecognizedText
+      if (lastText === null) {
+        setIsFailureSnackbarVisible(true)
+      }
+    }
+  }, [recognitionState])
 
   const {
     isPlaying,
@@ -126,6 +157,23 @@ export const MainScreen: React.FC<Props> = ({ navigation }) => {
         onSelect={handleRateSelect}
         onDismiss={() => setIsRateSelectorVisible(false)}
       />
+
+      <ListeningIndicator visible={isListeningModalVisible} />
+
+      <Snackbar
+        visible={isFailureSnackbarVisible}
+        onDismiss={() => setIsFailureSnackbarVisible(false)}
+        duration={3000}
+        style={{ backgroundColor: colors.errorContainer }}
+        action={{
+          label: '閉じる',
+          onPress: () => setIsFailureSnackbarVisible(false),
+        }}
+      >
+        <Text style={{ color: colors.onErrorContainer }}>
+          認識できませんでした
+        </Text>
+      </Snackbar>
     </View>
   )
 }


### PR DESCRIPTION
## Summary
ウェイクワード検出後に表示する「聞き取り中」モーダルと認識失敗スナックバーの実装。

## Changes
- **ListeningIndicator**: Siri風パルスアニメーション付き半透明モーダル（LISTENING_FOR_COMMAND/PROCESSING時に表示）
- **MainScreen**: ListeningIndicator統合 + 認識失敗時「認識できませんでした」スナックバー表示

## Test plan
- [ ] ウェイクワード検出後にモーダルが表示される
- [ ] パルスアニメーションが動作する
- [ ] コマンド認識成功でモーダルが閉じる
- [ ] 認識失敗でスナックバーが表示される
- [ ] スナックバーが3秒後に自動で閉じる

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)