### PR TITLE
[Frontend] ドロワー（ファイル一覧）UI実装 (#13)

### DIFF
--- a/src/components/drawer/DrawerContent.tsx
+++ b/src/components/drawer/DrawerContent.tsx
@@ -1,32 +1,122 @@
-import React from 'react'
+import React, { useState, useCallback } from 'react'
 import { View, StyleSheet } from 'react-native'
-import { Text, useTheme } from 'react-native-paper'
 import {
-  DrawerContentScrollView,
-  DrawerContentComponentProps,
-} from '@react-navigation/drawer'
+  Appbar,
+  Dialog,
+  Portal,
+  Text,
+  Button,
+  useTheme,
+} from 'react-native-paper'
+import { DrawerContentComponentProps } from '@react-navigation/drawer'
+import { AudioFile } from '../../types'
+import { useFileStore } from '../../stores/fileStore'
+import { usePlayerStore } from '../../stores/playerStore'
+import { useFileImport } from '../../hooks/useFileImport'
+import { fileService } from '../../services/fileService'
+import { FileList } from './FileList'
 
-/**
- * ドロワー内コンテンツ（ファイル一覧）
- * Issue #12 で本実装予定
- */
-export const DrawerContent: React.FC<DrawerContentComponentProps> = (props) => {
+export const DrawerContent: React.FC<DrawerContentComponentProps> = () => {
   const { colors } = useTheme()
+  const files = useFileStore((state) => state.files)
+  const selectedFileId = useFileStore((state) => state.selectedFileId)
+  const selectFile = useFileStore((state) => state.selectFile)
+  const removeFile = useFileStore((state) => state.removeFile)
+  const isPlaying = usePlayerStore((state) => state.isPlaying)
+  const { pickAndImportFile, isImporting } = useFileImport()
+
+  const [deleteTarget, setDeleteTarget] = useState<AudioFile | null>(null)
+  const [isDeleteDialogVisible, setIsDeleteDialogVisible] = useState(false)
+
+  const handleFileSelect = useCallback(
+    (id: string) => {
+      selectFile(id)
+    },
+    [selectFile]
+  )
+
+  const handleFileDelete = useCallback(
+    (file: AudioFile) => {
+      if (isPlaying && file.id === selectedFileId) {
+        setDeleteTarget(file)
+        setIsDeleteDialogVisible(true)
+        return
+      }
+      performDelete(file)
+    },
+    [isPlaying, selectedFileId]
+  )
+
+  const performDelete = useCallback(
+    async (file: AudioFile) => {
+      try {
+        await fileService.deleteFile(file.path)
+      } catch (error) {
+        console.error('[DrawerContent] deleteFile failed:', error)
+      }
+      removeFile(file.id)
+    },
+    [removeFile]
+  )
+
+  const handleConfirmDelete = useCallback(() => {
+    if (deleteTarget) {
+      performDelete(deleteTarget)
+    }
+    setIsDeleteDialogVisible(false)
+    setDeleteTarget(null)
+  }, [deleteTarget, performDelete])
+
+  const handleCancelDelete = useCallback(() => {
+    setIsDeleteDialogVisible(false)
+    setDeleteTarget(null)
+  }, [])
 
   return (
-    <DrawerContentScrollView
-      {...props}
-      style={[styles.container, { backgroundColor: colors.surface }]}
-    >
-      <View style={styles.placeholder}>
-        <Text
-          variant="bodySmall"
-          style={{ color: colors.onSurfaceVariant }}
+    <View style={[styles.container, { backgroundColor: colors.surface }]}>
+      <Appbar.Header
+        style={[styles.header, { backgroundColor: colors.surface }]}
+        statusBarHeight={0}
+      >
+        <Appbar.Content title="ファイル一覧" titleStyle={styles.headerTitle} />
+        <Appbar.Action
+          icon="plus"
+          onPress={pickAndImportFile}
+          disabled={isImporting}
+          accessibilityLabel="ファイルをインポート"
+        />
+      </Appbar.Header>
+
+      <FileList
+        files={files}
+        selectedFileId={selectedFileId}
+        onFileSelect={handleFileSelect}
+        onFileDelete={handleFileDelete}
+      />
+
+      <Portal>
+        <Dialog
+          visible={isDeleteDialogVisible}
+          onDismiss={handleCancelDelete}
         >
-          ファイル一覧（Issue #12 で実装予定）
-        </Text>
-      </View>
-    </DrawerContentScrollView>
+          <Dialog.Title>再生中のファイルを削除</Dialog.Title>
+          <Dialog.Content>
+            <Text variant="bodyMedium">
+              「{deleteTarget?.name}」は現在再生中です。削除しますか？
+            </Text>
+          </Dialog.Content>
+          <Dialog.Actions>
+            <Button onPress={handleCancelDelete}>キャンセル</Button>
+            <Button
+              onPress={handleConfirmDelete}
+              textColor={colors.error}
+            >
+              削除
+            </Button>
+          </Dialog.Actions>
+        </Dialog>
+      </Portal>
+    </View>
   )
 }
 
@@ -34,8 +124,11 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
-  placeholder: {
-    padding: 16,
-    alignItems: 'center',
+  header: {
+    elevation: 0,
+  },
+  headerTitle: {
+    fontSize: 18,
+    fontWeight: '600',
   },
 })

--- a/src/components/drawer/FileList.tsx
+++ b/src/components/drawer/FileList.tsx
@@ -1,0 +1,81 @@
+import React, { useCallback } from 'react'
+import { View, FlatList, StyleSheet } from 'react-native'
+import { Text, useTheme } from 'react-native-paper'
+import { AudioFile } from '../../types'
+import { FileListItem } from './FileListItem'
+
+interface FileListProps {
+  files: AudioFile[]
+  selectedFileId: string | null
+  onFileSelect: (id: string) => void
+  onFileDelete: (file: AudioFile) => void
+}
+
+export const FileList: React.FC<FileListProps> = ({
+  files,
+  selectedFileId,
+  onFileSelect,
+  onFileDelete,
+}) => {
+  const { colors } = useTheme()
+
+  const renderItem = useCallback(
+    ({ item }: { item: AudioFile }) => (
+      <FileListItem
+        file={item}
+        isSelected={item.id === selectedFileId}
+        onPress={onFileSelect}
+        onDelete={onFileDelete}
+      />
+    ),
+    [selectedFileId, onFileSelect, onFileDelete]
+  )
+
+  const keyExtractor = useCallback((item: AudioFile) => item.id, [])
+
+  if (files.length === 0) {
+    return (
+      <View style={styles.emptyContainer}>
+        <Text
+          variant="bodyMedium"
+          style={{ color: colors.onSurfaceVariant, textAlign: 'center' }}
+        >
+          ファイルがありません
+        </Text>
+        <Text
+          variant="bodySmall"
+          style={{
+            color: colors.onSurfaceVariant,
+            textAlign: 'center',
+            opacity: 0.7,
+            marginTop: 4,
+          }}
+        >
+          「+」ボタンからインポートしてください
+        </Text>
+      </View>
+    )
+  }
+
+  return (
+    <FlatList
+      data={files}
+      renderItem={renderItem}
+      keyExtractor={keyExtractor}
+      style={{ backgroundColor: colors.surface }}
+      contentContainerStyle={styles.listContent}
+    />
+  )
+}
+
+const styles = StyleSheet.create({
+  emptyContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+  },
+  listContent: {
+    paddingVertical: 8,
+  },
+})

--- a/src/components/drawer/FileListItem.tsx
+++ b/src/components/drawer/FileListItem.tsx
@@ -1,0 +1,206 @@
+import React, { useCallback, useRef } from 'react'
+import {
+  View,
+  StyleSheet,
+  Animated,
+  PanResponder,
+  Pressable,
+} from 'react-native'
+import { Text, useTheme } from 'react-native-paper'
+import { AudioFile } from '../../types'
+
+const SWIPE_THRESHOLD = -80
+const DELETE_BUTTON_WIDTH = 80
+
+interface FileListItemProps {
+  file: AudioFile
+  isSelected: boolean
+  onPress: (id: string) => void
+  onDelete: (file: AudioFile) => void
+}
+
+const formatDuration = (seconds: number): string => {
+  const minutes = Math.floor(seconds / 60)
+  const remainingSeconds = Math.floor(seconds % 60)
+  return `${minutes}:${remainingSeconds.toString().padStart(2, '0')}`
+}
+
+export const FileListItem: React.FC<FileListItemProps> = ({
+  file,
+  isSelected,
+  onPress,
+  onDelete,
+}) => {
+  const { colors } = useTheme()
+  const translateX = useRef(new Animated.Value(0)).current
+  const isSwipeOpen = useRef(false)
+
+  const panResponder = useRef(
+    PanResponder.create({
+      onMoveShouldSetPanResponder: (_, gestureState) => {
+        return Math.abs(gestureState.dx) > 10 && Math.abs(gestureState.dy) < 10
+      },
+      onPanResponderMove: (_, gestureState) => {
+        const newX = isSwipeOpen.current
+          ? gestureState.dx - DELETE_BUTTON_WIDTH
+          : gestureState.dx
+        if (newX <= 0) {
+          translateX.setValue(newX)
+        }
+      },
+      onPanResponderRelease: (_, gestureState) => {
+        const currentX = isSwipeOpen.current
+          ? gestureState.dx - DELETE_BUTTON_WIDTH
+          : gestureState.dx
+
+        if (currentX < SWIPE_THRESHOLD) {
+          Animated.spring(translateX, {
+            toValue: -DELETE_BUTTON_WIDTH,
+            useNativeDriver: true,
+          }).start()
+          isSwipeOpen.current = true
+        } else {
+          Animated.spring(translateX, {
+            toValue: 0,
+            useNativeDriver: true,
+          }).start()
+          isSwipeOpen.current = false
+        }
+      },
+    })
+  ).current
+
+  const handlePress = useCallback(() => {
+    if (isSwipeOpen.current) {
+      Animated.spring(translateX, {
+        toValue: 0,
+        useNativeDriver: true,
+      }).start()
+      isSwipeOpen.current = false
+      return
+    }
+    onPress(file.id)
+  }, [file.id, onPress, translateX])
+
+  const handleDelete = useCallback(() => {
+    Animated.timing(translateX, {
+      toValue: 0,
+      duration: 200,
+      useNativeDriver: true,
+    }).start(() => {
+      isSwipeOpen.current = false
+    })
+    onDelete(file)
+  }, [file, onDelete, translateX])
+
+  const displayName = file.name.replace(/\.[^.]+$/, '')
+
+  return (
+    <View style={styles.wrapper}>
+      <View style={styles.deleteButtonContainer}>
+        <Pressable
+          style={[
+            styles.deleteButton,
+            { backgroundColor: colors.error },
+          ]}
+          onPress={handleDelete}
+          accessibilityLabel={`${file.name}を削除`}
+          accessibilityRole="button"
+        >
+          <Text style={[styles.deleteText, { color: colors.onError }]}>
+            削除
+          </Text>
+        </Pressable>
+      </View>
+
+      <Animated.View
+        style={[
+          styles.itemContainer,
+          {
+            backgroundColor: isSelected
+              ? colors.primaryContainer
+              : colors.surface,
+            transform: [{ translateX }],
+          },
+        ]}
+        {...panResponder.panHandlers}
+      >
+        <Pressable
+          style={styles.contentArea}
+          onPress={handlePress}
+          accessibilityLabel={`${file.name}${isSelected ? '（選択中）' : ''}`}
+          accessibilityRole="button"
+          accessibilityState={{ selected: isSelected }}
+        >
+          <View style={styles.textContainer}>
+            <Text
+              variant="bodyLarge"
+              style={{
+                color: isSelected
+                  ? colors.onPrimaryContainer
+                  : colors.onSurface,
+              }}
+              numberOfLines={1}
+              ellipsizeMode="tail"
+            >
+              {displayName}
+            </Text>
+            {file.duration > 0 && (
+              <Text
+                variant="bodySmall"
+                style={{
+                  color: isSelected
+                    ? colors.onPrimaryContainer
+                    : colors.onSurfaceVariant,
+                  opacity: 0.7,
+                }}
+              >
+                {formatDuration(file.duration)}
+              </Text>
+            )}
+          </View>
+        </Pressable>
+      </Animated.View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    position: 'relative',
+    overflow: 'hidden',
+  },
+  deleteButtonContainer: {
+    position: 'absolute',
+    right: 0,
+    top: 0,
+    bottom: 0,
+    width: DELETE_BUTTON_WIDTH,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  deleteButton: {
+    width: '100%',
+    height: '100%',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  deleteText: {
+    fontWeight: '600',
+    fontSize: 14,
+  },
+  itemContainer: {
+    minHeight: 56,
+  },
+  contentArea: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    minHeight: 56,
+  },
+  textContainer: {
+    flex: 1,
+    gap: 2,
+  },
+})


### PR DESCRIPTION
## Summary
ドロワー内のファイル一覧UIを実装。

## Changes
- **FileListItem**: スワイプで削除ボタン表示、選択中ファイルはprimaryContainerでハイライト
- **FileList**: FlatList使用のファイル一覧 + Empty State
- **DrawerContent**: ヘッダーにインポートボタン(+)、再生中ファイル削除時の警告ダイアログ

## Test plan
- [ ] ファイル一覧が正しく表示される
- [ ] ファイルタップで選択・ハイライト切り替え
- [ ] 左スワイプで削除ボタン表示
- [ ] 再生中ファイル削除時に確認ダイアログ表示
- [ ] ファイルなし時のEmpty State表示
- [ ] 「+」ボタンでDocumentPickerが起動

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)