### PR TITLE
[Frontend] 設定画面UI実装 (#14)

### DIFF
--- a/src/components/drawer/DrawerContent.tsx
+++ b/src/components/drawer/DrawerContent.tsx
@@ -1,32 +1,122 @@
-import React from 'react'
+import React, { useState, useCallback } from 'react'
 import { View, StyleSheet } from 'react-native'
-import { Text, useTheme } from 'react-native-paper'
 import {
-  DrawerContentScrollView,
-  DrawerContentComponentProps,
-} from '@react-navigation/drawer'
+  Appbar,
+  Dialog,
+  Portal,
+  Text,
+  Button,
+  useTheme,
+} from 'react-native-paper'
+import { DrawerContentComponentProps } from '@react-navigation/drawer'
+import { AudioFile } from '../../types'
+import { useFileStore } from '../../stores/fileStore'
+import { usePlayerStore } from '../../stores/playerStore'
+import { useFileImport } from '../../hooks/useFileImport'
+import { fileService } from '../../services/fileService'
+import { FileList } from './FileList'
 
-/**
- * ドロワー内コンテンツ（ファイル一覧）
- * Issue #12 で本実装予定
- */
-export const DrawerContent: React.FC<DrawerContentComponentProps> = (props) => {
+export const DrawerContent: React.FC<DrawerContentComponentProps> = () => {
   const { colors } = useTheme()
+  const files = useFileStore((state) => state.files)
+  const selectedFileId = useFileStore((state) => state.selectedFileId)
+  const selectFile = useFileStore((state) => state.selectFile)
+  const removeFile = useFileStore((state) => state.removeFile)
+  const isPlaying = usePlayerStore((state) => state.isPlaying)
+  const { pickAndImportFile, isImporting } = useFileImport()
+
+  const [deleteTarget, setDeleteTarget] = useState<AudioFile | null>(null)
+  const [isDeleteDialogVisible, setIsDeleteDialogVisible] = useState(false)
+
+  const handleFileSelect = useCallback(
+    (id: string) => {
+      selectFile(id)
+    },
+    [selectFile]
+  )
+
+  const handleFileDelete = useCallback(
+    (file: AudioFile) => {
+      if (isPlaying && file.id === selectedFileId) {
+        setDeleteTarget(file)
+        setIsDeleteDialogVisible(true)
+        return
+      }
+      performDelete(file)
+    },
+    [isPlaying, selectedFileId]
+  )
+
+  const performDelete = useCallback(
+    async (file: AudioFile) => {
+      try {
+        await fileService.deleteFile(file.path)
+      } catch (error) {
+        console.error('[DrawerContent] deleteFile failed:', error)
+      }
+      removeFile(file.id)
+    },
+    [removeFile]
+  )
+
+  const handleConfirmDelete = useCallback(() => {
+    if (deleteTarget) {
+      performDelete(deleteTarget)
+    }
+    setIsDeleteDialogVisible(false)
+    setDeleteTarget(null)
+  }, [deleteTarget, performDelete])
+
+  const handleCancelDelete = useCallback(() => {
+    setIsDeleteDialogVisible(false)
+    setDeleteTarget(null)
+  }, [])
 
   return (
-    <DrawerContentScrollView
-      {...props}
-      style={[styles.container, { backgroundColor: colors.surface }]}
-    >
-      <View style={styles.placeholder}>
-        <Text
-          variant="bodySmall"
-          style={{ color: colors.onSurfaceVariant }}
+    <View style={[styles.container, { backgroundColor: colors.surface }]}>
+      <Appbar.Header
+        style={[styles.header, { backgroundColor: colors.surface }]}
+        statusBarHeight={0}
+      >
+        <Appbar.Content title="ファイル一覧" titleStyle={styles.headerTitle} />
+        <Appbar.Action
+          icon="plus"
+          onPress={pickAndImportFile}
+          disabled={isImporting}
+          accessibilityLabel="ファイルをインポート"
+        />
+      </Appbar.Header>
+
+      <FileList
+        files={files}
+        selectedFileId={selectedFileId}
+        onFileSelect={handleFileSelect}
+        onFileDelete={handleFileDelete}
+      />
+
+      <Portal>
+        <Dialog
+          visible={isDeleteDialogVisible}
+          onDismiss={handleCancelDelete}
         >
-          ファイル一覧（Issue #12 で実装予定）
-        </Text>
-      </View>
-    </DrawerContentScrollView>
+          <Dialog.Title>再生中のファイルを削除</Dialog.Title>
+          <Dialog.Content>
+            <Text variant="bodyMedium">
+              「{deleteTarget?.name}」は現在再生中です。削除しますか？
+            </Text>
+          </Dialog.Content>
+          <Dialog.Actions>
+            <Button onPress={handleCancelDelete}>キャンセル</Button>
+            <Button
+              onPress={handleConfirmDelete}
+              textColor={colors.error}
+            >
+              削除
+            </Button>
+          </Dialog.Actions>
+        </Dialog>
+      </Portal>
+    </View>
   )
 }
 
@@ -34,8 +124,11 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
-  placeholder: {
-    padding: 16,
-    alignItems: 'center',
+  header: {
+    elevation: 0,
+  },
+  headerTitle: {
+    fontSize: 18,
+    fontWeight: '600',
   },
 })

--- a/src/components/drawer/FileList.tsx
+++ b/src/components/drawer/FileList.tsx
@@ -1,0 +1,81 @@
+import React, { useCallback } from 'react'
+import { View, FlatList, StyleSheet } from 'react-native'
+import { Text, useTheme } from 'react-native-paper'
+import { AudioFile } from '../../types'
+import { FileListItem } from './FileListItem'
+
+interface FileListProps {
+  files: AudioFile[]
+  selectedFileId: string | null
+  onFileSelect: (id: string) => void
+  onFileDelete: (file: AudioFile) => void
+}
+
+export const FileList: React.FC<FileListProps> = ({
+  files,
+  selectedFileId,
+  onFileSelect,
+  onFileDelete,
+}) => {
+  const { colors } = useTheme()
+
+  const renderItem = useCallback(
+    ({ item }: { item: AudioFile }) => (
+      <FileListItem
+        file={item}
+        isSelected={item.id === selectedFileId}
+        onPress={onFileSelect}
+        onDelete={onFileDelete}
+      />
+    ),
+    [selectedFileId, onFileSelect, onFileDelete]
+  )
+
+  const keyExtractor = useCallback((item: AudioFile) => item.id, [])
+
+  if (files.length === 0) {
+    return (
+      <View style={styles.emptyContainer}>
+        <Text
+          variant="bodyMedium"
+          style={{ color: colors.onSurfaceVariant, textAlign: 'center' }}
+        >
+          ファイルがありません
+        </Text>
+        <Text
+          variant="bodySmall"
+          style={{
+            color: colors.onSurfaceVariant,
+            textAlign: 'center',
+            opacity: 0.7,
+            marginTop: 4,
+          }}
+        >
+          「+」ボタンからインポートしてください
+        </Text>
+      </View>
+    )
+  }
+
+  return (
+    <FlatList
+      data={files}
+      renderItem={renderItem}
+      keyExtractor={keyExtractor}
+      style={{ backgroundColor: colors.surface }}
+      contentContainerStyle={styles.listContent}
+    />
+  )
+}
+
+const styles = StyleSheet.create({
+  emptyContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+  },
+  listContent: {
+    paddingVertical: 8,
+  },
+})

--- a/src/components/drawer/FileListItem.tsx
+++ b/src/components/drawer/FileListItem.tsx
@@ -1,0 +1,206 @@
+import React, { useCallback, useRef } from 'react'
+import {
+  View,
+  StyleSheet,
+  Animated,
+  PanResponder,
+  Pressable,
+} from 'react-native'
+import { Text, useTheme } from 'react-native-paper'
+import { AudioFile } from '../../types'
+
+const SWIPE_THRESHOLD = -80
+const DELETE_BUTTON_WIDTH = 80
+
+interface FileListItemProps {
+  file: AudioFile
+  isSelected: boolean
+  onPress: (id: string) => void
+  onDelete: (file: AudioFile) => void
+}
+
+const formatDuration = (seconds: number): string => {
+  const minutes = Math.floor(seconds / 60)
+  const remainingSeconds = Math.floor(seconds % 60)
+  return `${minutes}:${remainingSeconds.toString().padStart(2, '0')}`
+}
+
+export const FileListItem: React.FC<FileListItemProps> = ({
+  file,
+  isSelected,
+  onPress,
+  onDelete,
+}) => {
+  const { colors } = useTheme()
+  const translateX = useRef(new Animated.Value(0)).current
+  const isSwipeOpen = useRef(false)
+
+  const panResponder = useRef(
+    PanResponder.create({
+      onMoveShouldSetPanResponder: (_, gestureState) => {
+        return Math.abs(gestureState.dx) > 10 && Math.abs(gestureState.dy) < 10
+      },
+      onPanResponderMove: (_, gestureState) => {
+        const newX = isSwipeOpen.current
+          ? gestureState.dx - DELETE_BUTTON_WIDTH
+          : gestureState.dx
+        if (newX <= 0) {
+          translateX.setValue(newX)
+        }
+      },
+      onPanResponderRelease: (_, gestureState) => {
+        const currentX = isSwipeOpen.current
+          ? gestureState.dx - DELETE_BUTTON_WIDTH
+          : gestureState.dx
+
+        if (currentX < SWIPE_THRESHOLD) {
+          Animated.spring(translateX, {
+            toValue: -DELETE_BUTTON_WIDTH,
+            useNativeDriver: true,
+          }).start()
+          isSwipeOpen.current = true
+        } else {
+          Animated.spring(translateX, {
+            toValue: 0,
+            useNativeDriver: true,
+          }).start()
+          isSwipeOpen.current = false
+        }
+      },
+    })
+  ).current
+
+  const handlePress = useCallback(() => {
+    if (isSwipeOpen.current) {
+      Animated.spring(translateX, {
+        toValue: 0,
+        useNativeDriver: true,
+      }).start()
+      isSwipeOpen.current = false
+      return
+    }
+    onPress(file.id)
+  }, [file.id, onPress, translateX])
+
+  const handleDelete = useCallback(() => {
+    Animated.timing(translateX, {
+      toValue: 0,
+      duration: 200,
+      useNativeDriver: true,
+    }).start(() => {
+      isSwipeOpen.current = false
+    })
+    onDelete(file)
+  }, [file, onDelete, translateX])
+
+  const displayName = file.name.replace(/\.[^.]+$/, '')
+
+  return (
+    <View style={styles.wrapper}>
+      <View style={styles.deleteButtonContainer}>
+        <Pressable
+          style={[
+            styles.deleteButton,
+            { backgroundColor: colors.error },
+          ]}
+          onPress={handleDelete}
+          accessibilityLabel={`${file.name}を削除`}
+          accessibilityRole="button"
+        >
+          <Text style={[styles.deleteText, { color: colors.onError }]}>
+            削除
+          </Text>
+        </Pressable>
+      </View>
+
+      <Animated.View
+        style={[
+          styles.itemContainer,
+          {
+            backgroundColor: isSelected
+              ? colors.primaryContainer
+              : colors.surface,
+            transform: [{ translateX }],
+          },
+        ]}
+        {...panResponder.panHandlers}
+      >
+        <Pressable
+          style={styles.contentArea}
+          onPress={handlePress}
+          accessibilityLabel={`${file.name}${isSelected ? '（選択中）' : ''}`}
+          accessibilityRole="button"
+          accessibilityState={{ selected: isSelected }}
+        >
+          <View style={styles.textContainer}>
+            <Text
+              variant="bodyLarge"
+              style={{
+                color: isSelected
+                  ? colors.onPrimaryContainer
+                  : colors.onSurface,
+              }}
+              numberOfLines={1}
+              ellipsizeMode="tail"
+            >
+              {displayName}
+            </Text>
+            {file.duration > 0 && (
+              <Text
+                variant="bodySmall"
+                style={{
+                  color: isSelected
+                    ? colors.onPrimaryContainer
+                    : colors.onSurfaceVariant,
+                  opacity: 0.7,
+                }}
+              >
+                {formatDuration(file.duration)}
+              </Text>
+            )}
+          </View>
+        </Pressable>
+      </Animated.View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    position: 'relative',
+    overflow: 'hidden',
+  },
+  deleteButtonContainer: {
+    position: 'absolute',
+    right: 0,
+    top: 0,
+    bottom: 0,
+    width: DELETE_BUTTON_WIDTH,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  deleteButton: {
+    width: '100%',
+    height: '100%',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  deleteText: {
+    fontWeight: '600',
+    fontSize: 14,
+  },
+  itemContainer: {
+    minHeight: 56,
+  },
+  contentArea: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    minHeight: 56,
+  },
+  textContainer: {
+    flex: 1,
+    gap: 2,
+  },
+})

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,34 +1,272 @@
-import React from 'react'
-import { View, StyleSheet } from 'react-native'
-import { Text, useTheme, Appbar } from 'react-native-paper'
+import React, { useState, useCallback, useMemo } from 'react'
+import { View, ScrollView, StyleSheet } from 'react-native'
+import {
+  Appbar,
+  TextInput,
+  Switch,
+  Text,
+  Button,
+  Divider,
+  useTheme,
+} from 'react-native-paper'
 import { NativeStackNavigationProp } from '@react-navigation/native-stack'
 import { RootStackParamList } from '../navigation/types'
+import { VoiceCommand } from '../types'
+import { useSettingsStore } from '../stores/settingsStore'
+import {
+  validateWakeWord,
+  validateCommandWord,
+  validateTimeout,
+} from '../utils/validation'
 
 type Props = {
   navigation: NativeStackNavigationProp<RootStackParamList, 'Settings'>
 }
 
-/**
- * 設定画面
- * Issue #13 で本実装予定
- */
+const COMMAND_LABELS: Record<VoiceCommand, string> = {
+  [VoiceCommand.PLAY]: '再生',
+  [VoiceCommand.PAUSE]: '停止',
+  [VoiceCommand.NEXT]: '次',
+  [VoiceCommand.PREVIOUS]: '前',
+  [VoiceCommand.SKIP_TO_START]: '最初から',
+  [VoiceCommand.VOLUME_UP]: '音量上げて',
+  [VoiceCommand.VOLUME_DOWN]: '音量下げて',
+}
+
+type FieldErrors = {
+  wakeWord: string | null
+  commands: Record<VoiceCommand, string | null>
+  timeout: string | null
+}
+
+const INITIAL_ERRORS: FieldErrors = {
+  wakeWord: null,
+  commands: {
+    [VoiceCommand.PLAY]: null,
+    [VoiceCommand.PAUSE]: null,
+    [VoiceCommand.NEXT]: null,
+    [VoiceCommand.PREVIOUS]: null,
+    [VoiceCommand.SKIP_TO_START]: null,
+    [VoiceCommand.VOLUME_UP]: null,
+    [VoiceCommand.VOLUME_DOWN]: null,
+  },
+  timeout: null,
+}
+
 export const SettingsScreen: React.FC<Props> = ({ navigation }) => {
   const { colors } = useTheme()
 
+  const storeWakeWord = useSettingsStore((state) => state.wakeWord)
+  const storeCommands = useSettingsStore((state) => state.commands)
+  const storeTimeoutSeconds = useSettingsStore((state) => state.timeoutSeconds)
+  const storeSoundEnabled = useSettingsStore((state) => state.soundEnabled)
+  const updateSettings = useSettingsStore((state) => state.updateSettings)
+
+  const [wakeWord, setWakeWord] = useState(storeWakeWord)
+  const [commands, setCommands] = useState({ ...storeCommands })
+  const [timeoutText, setTimeoutText] = useState(String(storeTimeoutSeconds))
+  const [soundEnabled, setSoundEnabled] = useState(storeSoundEnabled)
+  const [errors, setErrors] = useState<FieldErrors>(INITIAL_ERRORS)
+
+  const commandKeys = useMemo(
+    () => Object.values(VoiceCommand),
+    []
+  )
+
+  const validateWakeWordField = useCallback(() => {
+    const error = validateWakeWord(wakeWord)
+    setErrors((prev) => ({ ...prev, wakeWord: error }))
+    return error === null
+  }, [wakeWord])
+
+  const validateCommandField = useCallback(
+    (command: VoiceCommand) => {
+      const otherValues = commandKeys
+        .filter((key) => key !== command)
+        .map((key) => commands[key])
+      const error = validateCommandWord(
+        commands[command],
+        otherValues,
+        wakeWord
+      )
+      setErrors((prev) => ({
+        ...prev,
+        commands: { ...prev.commands, [command]: error },
+      }))
+      return error === null
+    },
+    [commands, commandKeys, wakeWord]
+  )
+
+  const validateTimeoutField = useCallback(() => {
+    const error = validateTimeout(timeoutText)
+    setErrors((prev) => ({ ...prev, timeout: error }))
+    return error === null
+  }, [timeoutText])
+
+  const handleCommandChange = useCallback(
+    (command: VoiceCommand, value: string) => {
+      setCommands((prev) => ({ ...prev, [command]: value }))
+    },
+    []
+  )
+
+  const handleSave = useCallback(() => {
+    const isWakeWordValid = validateWakeWordField()
+    const isTimeoutValid = validateTimeoutField()
+    const commandValidations = commandKeys.map((key) =>
+      validateCommandField(key)
+    )
+    const areCommandsValid = commandValidations.every(Boolean)
+
+    if (!isWakeWordValid || !isTimeoutValid || !areCommandsValid) return
+
+    updateSettings({
+      wakeWord: wakeWord.trim(),
+      commands,
+      timeoutSeconds: Number(timeoutText),
+      soundEnabled,
+      onboardingDone: useSettingsStore.getState().onboardingDone,
+    })
+
+    navigation.goBack()
+  }, [
+    wakeWord,
+    commands,
+    timeoutText,
+    soundEnabled,
+    validateWakeWordField,
+    validateTimeoutField,
+    validateCommandField,
+    commandKeys,
+    updateSettings,
+    navigation,
+  ])
+
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
-      <Appbar.Header>
+      <Appbar.Header style={{ backgroundColor: colors.surface }}>
         <Appbar.BackAction
           onPress={() => navigation.goBack()}
           accessibilityLabel="戻る"
         />
         <Appbar.Content title="設定" />
+        <Appbar.Action
+          icon="check"
+          onPress={handleSave}
+          accessibilityLabel="保存"
+        />
       </Appbar.Header>
-      <View style={styles.body}>
-        <Text variant="bodyMedium" style={{ color: colors.onSurfaceVariant }}>
-          設定画面（Issue #13 で実装予定）
+
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={styles.scrollContent}
+      >
+        <Text
+          variant="titleMedium"
+          style={[styles.sectionTitle, { color: colors.primary }]}
+        >
+          ウェイクワード
         </Text>
-      </View>
+        <TextInput
+          mode="outlined"
+          label="ウェイクワード"
+          value={wakeWord}
+          onChangeText={setWakeWord}
+          onBlur={validateWakeWordField}
+          error={errors.wakeWord !== null}
+          accessibilityLabel="ウェイクワード入力"
+        />
+        {errors.wakeWord && (
+          <Text
+            variant="bodySmall"
+            style={[styles.errorText, { color: colors.error }]}
+          >
+            {errors.wakeWord}
+          </Text>
+        )}
+
+        <Divider style={styles.divider} />
+
+        <Text
+          variant="titleMedium"
+          style={[styles.sectionTitle, { color: colors.primary }]}
+        >
+          コマンド語
+        </Text>
+        {commandKeys.map((command) => (
+          <View key={command} style={styles.commandField}>
+            <TextInput
+              mode="outlined"
+              label={COMMAND_LABELS[command]}
+              value={commands[command]}
+              onChangeText={(value) => handleCommandChange(command, value)}
+              onBlur={() => validateCommandField(command)}
+              error={errors.commands[command] !== null}
+              accessibilityLabel={`${COMMAND_LABELS[command]}コマンド入力`}
+            />
+            {errors.commands[command] && (
+              <Text
+                variant="bodySmall"
+                style={[styles.errorText, { color: colors.error }]}
+              >
+                {errors.commands[command]}
+              </Text>
+            )}
+          </View>
+        ))}
+
+        <Divider style={styles.divider} />
+
+        <Text
+          variant="titleMedium"
+          style={[styles.sectionTitle, { color: colors.primary }]}
+        >
+          タイムアウト
+        </Text>
+        <TextInput
+          mode="outlined"
+          label="タイムアウト（秒）"
+          value={timeoutText}
+          onChangeText={setTimeoutText}
+          onBlur={validateTimeoutField}
+          keyboardType="number-pad"
+          error={errors.timeout !== null}
+          accessibilityLabel="タイムアウト秒数入力"
+        />
+        {errors.timeout && (
+          <Text
+            variant="bodySmall"
+            style={[styles.errorText, { color: colors.error }]}
+          >
+            {errors.timeout}
+          </Text>
+        )}
+
+        <Divider style={styles.divider} />
+
+        <View style={styles.switchRow}>
+          <Text variant="bodyLarge" style={{ color: colors.onSurface }}>
+            フィードバック音
+          </Text>
+          <Switch
+            value={soundEnabled}
+            onValueChange={setSoundEnabled}
+            accessibilityLabel="フィードバック音の切り替え"
+          />
+        </View>
+
+        <Divider style={styles.divider} />
+
+        <Button
+          mode="outlined"
+          onPress={handleSave}
+          style={styles.saveButton}
+          accessibilityLabel="設定を保存"
+        >
+          保存
+        </Button>
+      </ScrollView>
     </View>
   )
 }
@@ -37,9 +275,34 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
-  body: {
+  scrollView: {
     flex: 1,
+  },
+  scrollContent: {
+    padding: 16,
+    paddingBottom: 40,
+  },
+  sectionTitle: {
+    marginBottom: 8,
+    fontWeight: '600',
+  },
+  commandField: {
+    marginBottom: 8,
+  },
+  errorText: {
+    marginTop: 4,
+    marginLeft: 4,
+  },
+  divider: {
+    marginVertical: 16,
+  },
+  switchRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
     alignItems: 'center',
-    justifyContent: 'center',
+    paddingVertical: 8,
+  },
+  saveButton: {
+    marginTop: 8,
   },
 })


### PR DESCRIPTION
## Summary
設定画面のUIとバリデーション付きフォームの実装。

## Changes
- **ウェイクワード**: テキスト入力（2〜20文字、記号不可）
- **コマンド語 × 7項目**: 重複・ウェイクワード重複チェック付き
- **タイムアウト**: 数値入力（3〜30秒の整数）
- **フィードバック音**: ON/OFFスイッチ
- onBlur + 保存時にバリデーション実行、エラーはフィールド直下にインライン表示
- ヘッダーチェックマーク + 画面下部の保存ボタン

## Test plan
- [ ] 各フィールドに不正値を入力してエラーメッセージが表示される
- [ ] 重複コマンド語でエラー表示
- [ ] ウェイクワードとコマンド語の重複でエラー表示
- [ ] 正常値で保存 → storeに反映される
- [ ] 戻るボタンで保存せずに戻れる

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)