### PR TITLE
[Frontend] オンボーディング画面実装 (#16)

### DIFF
--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -5,7 +5,9 @@ import { useTheme } from 'react-native-paper'
 import { RootStackParamList, DrawerParamList } from './types'
 import { MainScreen } from '../screens/MainScreen'
 import { SettingsScreen } from '../screens/SettingsScreen'
+import { OnboardingScreen } from '../screens/OnboardingScreen'
 import { DrawerContent } from '../components/drawer/DrawerContent'
+import { useSettingsStore } from '../stores/settingsStore'
 
 const Stack = createNativeStackNavigator<RootStackParamList>()
 const Drawer = createDrawerNavigator<DrawerParamList>()
@@ -36,11 +38,16 @@ const DrawerNavigator: React.FC = () => {
 
 /**
  * ルートナビゲーター
- * DrawerNavigator（メイン） + Settings（スタック）
+ * Onboarding（初回のみ） + DrawerNavigator（メイン） + Settings（スタック）
  */
 export const RootNavigator: React.FC = () => {
+  const onboardingDone = useSettingsStore((state) => state.onboardingDone)
+
   return (
     <Stack.Navigator screenOptions={{ headerShown: false }}>
+      {!onboardingDone && (
+        <Stack.Screen name="Onboarding" component={OnboardingScreen} />
+      )}
       <Stack.Screen name="Drawer" component={DrawerNavigator} />
       <Stack.Screen name="Settings" component={SettingsScreen} />
     </Stack.Navigator>

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -9,6 +9,7 @@ export type DrawerParamList = {
  * スタックナビゲーターのスクリーン定義
  */
 export type RootStackParamList = {
+  Onboarding: undefined
   Drawer: undefined
   Settings: undefined
 }

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -1,0 +1,182 @@
+import React, { useCallback } from 'react'
+import { View, StyleSheet, ScrollView } from 'react-native'
+import { Text, Button, useTheme } from 'react-native-paper'
+import { NativeStackNavigationProp } from '@react-navigation/native-stack'
+import { RootStackParamList } from '../navigation/types'
+import { useSettingsStore } from '../stores/settingsStore'
+
+type Props = {
+  navigation: NativeStackNavigationProp<RootStackParamList, 'Onboarding'>
+}
+
+interface OnboardingItem {
+  icon: string
+  title: string
+  description: string
+}
+
+const ONBOARDING_ITEMS: OnboardingItem[] = [
+  {
+    icon: '📁',
+    title: 'ファイルをインポート',
+    description:
+      'ドロワーメニューの「+」ボタンをタップして、mp3・wav・m4aファイルをインポートします。',
+  },
+  {
+    icon: '🎵',
+    title: 'ファイルを選択して再生',
+    description:
+      'ドロワーのファイル一覧からタップして選択。再生ボタンで音楽を再生します。',
+  },
+  {
+    icon: '🎙️',
+    title: 'ウェイクワードで起動',
+    description:
+      'デフォルトは「はい行きます」。イヤホンマイクに向かって発話すると音声操作モードになります。',
+  },
+  {
+    icon: '📊',
+    title: '10分割バーで素早く移動',
+    description:
+      '曲を10等分した縦型バーの各セグメントをタップすると、その位置から再生が始まります。',
+  },
+]
+
+export const OnboardingScreen: React.FC<Props> = ({ navigation }) => {
+  const { colors } = useTheme()
+  const updateSettings = useSettingsStore((state) => state.updateSettings)
+
+  const handleStart = useCallback(() => {
+    updateSettings({ onboardingDone: true })
+    navigation.replace('Drawer')
+  }, [navigation, updateSettings])
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+      >
+        <View style={styles.header}>
+          <Text
+            variant="headlineMedium"
+            style={[styles.appName, { color: colors.primary }]}
+          >
+            Autopl
+          </Text>
+          <Text
+            variant="titleMedium"
+            style={[styles.subtitle, { color: colors.onSurfaceVariant }]}
+          >
+            音声操作ダンス練習プレイヤー
+          </Text>
+        </View>
+
+        <View style={styles.itemsContainer}>
+          {ONBOARDING_ITEMS.map((item, index) => (
+            <View
+              key={index}
+              style={[
+                styles.item,
+                { backgroundColor: colors.surfaceVariant },
+              ]}
+            >
+              <Text style={styles.itemIcon}>{item.icon}</Text>
+              <View style={styles.itemText}>
+                <Text
+                  variant="titleSmall"
+                  style={{ color: colors.onSurface, fontWeight: '600' }}
+                >
+                  {item.title}
+                </Text>
+                <Text
+                  variant="bodyMedium"
+                  style={{
+                    color: colors.onSurfaceVariant,
+                    marginTop: 4,
+                    lineHeight: 20,
+                  }}
+                >
+                  {item.description}
+                </Text>
+              </View>
+            </View>
+          ))}
+        </View>
+      </ScrollView>
+
+      <View
+        style={[
+          styles.footer,
+          {
+            backgroundColor: colors.background,
+            borderTopColor: colors.surfaceVariant,
+          },
+        ]}
+      >
+        <Button
+          mode="contained"
+          onPress={handleStart}
+          style={styles.startButton}
+          contentStyle={styles.startButtonContent}
+          accessibilityLabel="使い始める"
+        >
+          使い始める
+        </Button>
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
+    padding: 24,
+    paddingBottom: 16,
+  },
+  header: {
+    alignItems: 'center',
+    marginTop: 40,
+    marginBottom: 40,
+  },
+  appName: {
+    fontWeight: '700',
+    letterSpacing: 1,
+  },
+  subtitle: {
+    marginTop: 8,
+  },
+  itemsContainer: {
+    gap: 12,
+  },
+  item: {
+    flexDirection: 'row',
+    padding: 16,
+    borderRadius: 12,
+    alignItems: 'flex-start',
+    gap: 16,
+  },
+  itemIcon: {
+    fontSize: 28,
+    lineHeight: 36,
+  },
+  itemText: {
+    flex: 1,
+  },
+  footer: {
+    padding: 24,
+    borderTopWidth: 1,
+  },
+  startButton: {
+    borderRadius: 12,
+  },
+  startButtonContent: {
+    paddingVertical: 6,
+  },
+})


### PR DESCRIPTION
## Summary
初回起動時のみ表示するオンボーディング画面の実装。

## Changes
- **OnboardingScreen**: 4ステップチュートリアル（インポート・ファイル選択・ウェイクワード・10分割バー）
- **RootNavigator**: `onboardingDone=false` のときOnboarding画面を先頭に表示
- **types.ts**: `Onboarding` をRootStackParamListに追加

## 動作フロー
1. 初回起動 → OnboardingScreen表示
2. 「使い始める」タップ → `onboardingDone=true`保存 → Drawer画面へreplace
3. 以降の起動 → Drawer画面が直接表示

## Test plan
- [ ] 初回起動でオンボーディングが表示される
- [ ] 「使い始める」でメイン画面に遷移する
- [ ] 2回目以降の起動でオンボーディングが表示されない

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)