### PR TITLE
[Backend] Share Extension実装（他アプリからのインポート） (#19)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -7,6 +7,12 @@ import { SafeAreaProvider } from 'react-native-safe-area-context'
 import { StatusBar } from 'expo-status-bar'
 import { AutoplLightTheme, AutoplDarkTheme } from './src/theme'
 import { RootNavigator } from './src/navigation/RootNavigator'
+import { useAppRestore } from './src/hooks/useAppRestore'
+
+function AppContent() {
+  useAppRestore()
+  return <RootNavigator />
+}
 
 export default function App() {
   const colorScheme = useColorScheme()
@@ -19,7 +25,7 @@ export default function App() {
         <PaperProvider theme={theme}>
           <NavigationContainer>
             <StatusBar style={isDark ? 'light' : 'dark'} />
-            <RootNavigator />
+            <AppContent />
           </NavigationContainer>
         </PaperProvider>
       </SafeAreaProvider>

--- a/App.tsx
+++ b/App.tsx
@@ -8,9 +8,11 @@ import { StatusBar } from 'expo-status-bar'
 import { AutoplLightTheme, AutoplDarkTheme } from './src/theme'
 import { RootNavigator } from './src/navigation/RootNavigator'
 import { useAppRestore } from './src/hooks/useAppRestore'
+import { useShareHandler } from './src/hooks/useShareHandler'
 
 function AppContent() {
   useAppRestore()
+  useShareHandler()
   return <RootNavigator />
 }
 

--- a/app.json
+++ b/app.json
@@ -16,6 +16,7 @@
       "bundleIdentifier": "com.shogonakamura.autopl",
       "minimumOsVersion": "16.0"
     },
+    "scheme": "autopl",
     "web": {
       "favicon": "./assets/favicon.png"
     }

--- a/src/components/common/StatusBanners.tsx
+++ b/src/components/common/StatusBanners.tsx
@@ -1,0 +1,69 @@
+import React from 'react'
+import { View, StyleSheet, Pressable, Linking } from 'react-native'
+import { Text, useTheme } from 'react-native-paper'
+import { useVoiceStore } from '../../stores/voiceStore'
+
+/**
+ * オフライン・マイク権限拒否時のバナー表示
+ */
+export const StatusBanners: React.FC = () => {
+  const { colors } = useTheme()
+  const isOnline = useVoiceStore((state) => state.isOnline)
+  const hasMicPermission = useVoiceStore((state) => state.hasMicPermission)
+
+  const handleOpenSettings = () => {
+    Linking.openSettings()
+  }
+
+  if (hasMicPermission && isOnline) return null
+
+  return (
+    <View style={styles.container}>
+      {!hasMicPermission && (
+        <Pressable
+          style={[styles.banner, { backgroundColor: colors.errorContainer }]}
+          onPress={handleOpenSettings}
+          accessibilityLabel="設定アプリでマイクの使用を許可する"
+          accessibilityRole="button"
+        >
+          <Text
+            variant="bodySmall"
+            style={[styles.bannerText, { color: colors.onErrorContainer }]}
+          >
+            マイクの使用が許可されていないため音声操作が使用できません。タップして設定アプリから許可してください。
+          </Text>
+        </Pressable>
+      )}
+      {hasMicPermission && !isOnline && (
+        <View
+          style={[
+            styles.banner,
+            { backgroundColor: colors.secondaryContainer },
+          ]}
+          accessibilityLabel="オフライン状態の通知"
+        >
+          <Text
+            variant="bodySmall"
+            style={[styles.bannerText, { color: colors.onSecondaryContainer }]}
+          >
+            オンラインになると音声認識の精度が向上します
+          </Text>
+        </View>
+      )}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    width: '100%',
+  },
+  banner: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+  },
+  bannerText: {
+    textAlign: 'center',
+    lineHeight: 18,
+  },
+})

--- a/src/hooks/useAppRestore.ts
+++ b/src/hooks/useAppRestore.ts
@@ -1,0 +1,77 @@
+import { useEffect, useRef } from 'react'
+import NetInfo from '@react-native-community/netinfo'
+import { ExpoSpeechRecognitionModule } from 'expo-speech-recognition'
+import { useFileStore } from '../stores/fileStore'
+import { useVoiceStore } from '../stores/voiceStore'
+import { fileService } from '../services/fileService'
+
+/**
+ * アプリ起動時の復元フック
+ *
+ * Zustand persistによりファイル一覧・選択ファイルID・設定値は
+ * AsyncStorageから自動復元される。
+ * このフックでは以下を行う:
+ * 1. 選択ファイルがディスク上に存在するか検証（存在しなければ選択解除）
+ * 2. ファイル一覧の存在しないファイルを除去
+ * 3. オンライン状態の初期検出
+ * 4. マイク権限の確認
+ */
+export const useAppRestore = (): void => {
+  const hasRestored = useRef(false)
+
+  const files = useFileStore((state) => state.files)
+  const selectedFileId = useFileStore((state) => state.selectedFileId)
+  const removeFile = useFileStore((state) => state.removeFile)
+  const clearSelection = useFileStore((state) => state.clearSelection)
+  const setIsOnline = useVoiceStore((state) => state.setIsOnline)
+  const setHasMicPermission = useVoiceStore(
+    (state) => state.setHasMicPermission
+  )
+
+  useEffect(() => {
+    if (hasRestored.current) return
+    hasRestored.current = true
+
+    const restore = async () => {
+      // 1. ネットワーク状態確認
+      try {
+        const netState = await NetInfo.fetch()
+        setIsOnline(netState.isConnected ?? true)
+      } catch (error) {
+        console.error('[useAppRestore] NetInfo.fetch failed:', error)
+      }
+
+      // 2. マイク権限確認
+      try {
+        const permissionResult =
+          await ExpoSpeechRecognitionModule.getPermissionsAsync()
+        setHasMicPermission(permissionResult.granted)
+      } catch (error) {
+        console.error('[useAppRestore] getPermissionsAsync failed:', error)
+      }
+
+      // 3. ファイル存在検証（ディスクから削除されたファイルを除去）
+      try {
+        const missingFileIds: string[] = []
+        for (const file of files) {
+          if (!fileService.fileExists(file.path)) {
+            missingFileIds.push(file.id)
+          }
+        }
+        for (const id of missingFileIds) {
+          console.warn(`[useAppRestore] File not found on disk, removing: ${id}`)
+          removeFile(id)
+        }
+
+        // 4. 選択中ファイルが除去されていれば選択解除
+        if (selectedFileId && missingFileIds.includes(selectedFileId)) {
+          clearSelection()
+        }
+      } catch (error) {
+        console.error('[useAppRestore] file validation failed:', error)
+      }
+    }
+
+    restore()
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+}

--- a/src/hooks/useShareHandler.ts
+++ b/src/hooks/useShareHandler.ts
@@ -1,0 +1,68 @@
+import { useEffect, useCallback } from 'react'
+import { Linking } from 'react-native'
+import { useFileImport } from './useFileImport'
+
+/**
+ * Share Extensionからのファイル受信ハンドラ
+ *
+ * Share Extensionは共有されたファイルを App Group の共有コンテナに保存し、
+ * カスタムURLスキーム `autopl://import?url=<encoded-file-uri>&name=<encoded-name>&size=<size>`
+ * でメインアプリを起動する。
+ * このフックはそのURLを受信してfileImportフローに流す。
+ *
+ * ## iOS Share Extension セットアップ（ネイティブ設定）
+ * 1. Xcodeで Share Extension ターゲットを追加
+ * 2. App Groups 設定（group.com.shogonakamura.autopl）
+ * 3. Share ExtensionのInfo.plistにNSExtensionActivationRuleでmp3/wav/m4aを指定
+ * 4. ShareViewController.swiftで共有ファイルをApp Groupsコンテナにコピーし
+ *    openURL("autopl://import?url=...&name=...&size=...")を呼び出す
+ */
+export const useShareHandler = (): void => {
+  const { importFromUri } = useFileImport()
+
+  const handleUrl = useCallback(
+    async (url: string) => {
+      if (!url.startsWith('autopl://import')) return
+
+      try {
+        const parsed = new URL(url)
+        const fileUrl = parsed.searchParams.get('url')
+        const fileName = parsed.searchParams.get('name')
+        const fileSize = Number(parsed.searchParams.get('size') ?? '0')
+
+        if (!fileUrl || !fileName) {
+          console.warn('[useShareHandler] Missing url or name in share URL')
+          return
+        }
+
+        const decodedUrl = decodeURIComponent(fileUrl)
+        const decodedName = decodeURIComponent(fileName)
+
+        await importFromUri(decodedUrl, decodedName, fileSize)
+      } catch (error) {
+        console.error('[useShareHandler] Failed to handle share URL:', error)
+      }
+    },
+    [importFromUri]
+  )
+
+  useEffect(() => {
+    // アプリがバックグラウンドから起動されたときのURL処理
+    const subscription = Linking.addEventListener('url', ({ url }) => {
+      handleUrl(url)
+    })
+
+    // コールドスタート（アプリが閉じている状態から起動）のURL処理
+    let cancelled = false
+    Linking.getInitialURL().then((url) => {
+      if (!cancelled && url) {
+        handleUrl(url)
+      }
+    })
+
+    return () => {
+      subscription.remove()
+      cancelled = true
+    }
+  }, [handleUrl])
+}

--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -5,7 +5,9 @@ import { useTheme } from 'react-native-paper'
 import { RootStackParamList, DrawerParamList } from './types'
 import { MainScreen } from '../screens/MainScreen'
 import { SettingsScreen } from '../screens/SettingsScreen'
+import { OnboardingScreen } from '../screens/OnboardingScreen'
 import { DrawerContent } from '../components/drawer/DrawerContent'
+import { useSettingsStore } from '../stores/settingsStore'
 
 const Stack = createNativeStackNavigator<RootStackParamList>()
 const Drawer = createDrawerNavigator<DrawerParamList>()
@@ -36,11 +38,16 @@ const DrawerNavigator: React.FC = () => {
 
 /**
  * ルートナビゲーター
- * DrawerNavigator（メイン） + Settings（スタック）
+ * Onboarding（初回のみ） + DrawerNavigator（メイン） + Settings（スタック）
  */
 export const RootNavigator: React.FC = () => {
+  const onboardingDone = useSettingsStore((state) => state.onboardingDone)
+
   return (
     <Stack.Navigator screenOptions={{ headerShown: false }}>
+      {!onboardingDone && (
+        <Stack.Screen name="Onboarding" component={OnboardingScreen} />
+      )}
       <Stack.Screen name="Drawer" component={DrawerNavigator} />
       <Stack.Screen name="Settings" component={SettingsScreen} />
     </Stack.Navigator>

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -9,6 +9,7 @@ export type DrawerParamList = {
  * スタックナビゲーターのスクリーン定義
  */
 export type RootStackParamList = {
+  Onboarding: undefined
   Drawer: undefined
   Settings: undefined
 }

--- a/src/screens/MainScreen.tsx
+++ b/src/screens/MainScreen.tsx
@@ -9,6 +9,7 @@ import { SegmentedProgressBar } from '../components/player/SegmentedProgressBar'
 import { PlayerControls } from '../components/player/PlayerControls'
 import { PlaybackRateSelector } from '../components/player/PlaybackRateSelector'
 import { ListeningIndicator } from '../components/player/ListeningIndicator'
+import { StatusBanners } from '../components/common/StatusBanners'
 import { useAudioPlayer } from '../hooks/useAudioPlayer'
 import { useVoiceStore } from '../stores/voiceStore'
 import { PlaybackRate, VoiceRecognitionState } from '../types'
@@ -115,6 +116,8 @@ export const MainScreen: React.FC<Props> = ({ navigation }) => {
           accessibilityLabel="設定"
         />
       </Appbar.Header>
+
+      <StatusBanners />
 
       {selectedFile ? (
         <SegmentedProgressBar

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -1,0 +1,182 @@
+import React, { useCallback } from 'react'
+import { View, StyleSheet, ScrollView } from 'react-native'
+import { Text, Button, useTheme } from 'react-native-paper'
+import { NativeStackNavigationProp } from '@react-navigation/native-stack'
+import { RootStackParamList } from '../navigation/types'
+import { useSettingsStore } from '../stores/settingsStore'
+
+type Props = {
+  navigation: NativeStackNavigationProp<RootStackParamList, 'Onboarding'>
+}
+
+interface OnboardingItem {
+  icon: string
+  title: string
+  description: string
+}
+
+const ONBOARDING_ITEMS: OnboardingItem[] = [
+  {
+    icon: '📁',
+    title: 'ファイルをインポート',
+    description:
+      'ドロワーメニューの「+」ボタンをタップして、mp3・wav・m4aファイルをインポートします。',
+  },
+  {
+    icon: '🎵',
+    title: 'ファイルを選択して再生',
+    description:
+      'ドロワーのファイル一覧からタップして選択。再生ボタンで音楽を再生します。',
+  },
+  {
+    icon: '🎙️',
+    title: 'ウェイクワードで起動',
+    description:
+      'デフォルトは「はい行きます」。イヤホンマイクに向かって発話すると音声操作モードになります。',
+  },
+  {
+    icon: '📊',
+    title: '10分割バーで素早く移動',
+    description:
+      '曲を10等分した縦型バーの各セグメントをタップすると、その位置から再生が始まります。',
+  },
+]
+
+export const OnboardingScreen: React.FC<Props> = ({ navigation }) => {
+  const { colors } = useTheme()
+  const updateSettings = useSettingsStore((state) => state.updateSettings)
+
+  const handleStart = useCallback(() => {
+    updateSettings({ onboardingDone: true })
+    navigation.replace('Drawer')
+  }, [navigation, updateSettings])
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+      >
+        <View style={styles.header}>
+          <Text
+            variant="headlineMedium"
+            style={[styles.appName, { color: colors.primary }]}
+          >
+            Autopl
+          </Text>
+          <Text
+            variant="titleMedium"
+            style={[styles.subtitle, { color: colors.onSurfaceVariant }]}
+          >
+            音声操作ダンス練習プレイヤー
+          </Text>
+        </View>
+
+        <View style={styles.itemsContainer}>
+          {ONBOARDING_ITEMS.map((item, index) => (
+            <View
+              key={index}
+              style={[
+                styles.item,
+                { backgroundColor: colors.surfaceVariant },
+              ]}
+            >
+              <Text style={styles.itemIcon}>{item.icon}</Text>
+              <View style={styles.itemText}>
+                <Text
+                  variant="titleSmall"
+                  style={{ color: colors.onSurface, fontWeight: '600' }}
+                >
+                  {item.title}
+                </Text>
+                <Text
+                  variant="bodyMedium"
+                  style={{
+                    color: colors.onSurfaceVariant,
+                    marginTop: 4,
+                    lineHeight: 20,
+                  }}
+                >
+                  {item.description}
+                </Text>
+              </View>
+            </View>
+          ))}
+        </View>
+      </ScrollView>
+
+      <View
+        style={[
+          styles.footer,
+          {
+            backgroundColor: colors.background,
+            borderTopColor: colors.surfaceVariant,
+          },
+        ]}
+      >
+        <Button
+          mode="contained"
+          onPress={handleStart}
+          style={styles.startButton}
+          contentStyle={styles.startButtonContent}
+          accessibilityLabel="使い始める"
+        >
+          使い始める
+        </Button>
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
+    padding: 24,
+    paddingBottom: 16,
+  },
+  header: {
+    alignItems: 'center',
+    marginTop: 40,
+    marginBottom: 40,
+  },
+  appName: {
+    fontWeight: '700',
+    letterSpacing: 1,
+  },
+  subtitle: {
+    marginTop: 8,
+  },
+  itemsContainer: {
+    gap: 12,
+  },
+  item: {
+    flexDirection: 'row',
+    padding: 16,
+    borderRadius: 12,
+    alignItems: 'flex-start',
+    gap: 16,
+  },
+  itemIcon: {
+    fontSize: 28,
+    lineHeight: 36,
+  },
+  itemText: {
+    flex: 1,
+  },
+  footer: {
+    padding: 24,
+    borderTopWidth: 1,
+  },
+  startButton: {
+    borderRadius: 12,
+  },
+  startButtonContent: {
+    paddingVertical: 6,
+  },
+})

--- a/src/stores/voiceStore.ts
+++ b/src/stores/voiceStore.ts
@@ -5,12 +5,14 @@ interface VoiceState {
   recognitionState: VoiceRecognitionState
   isOnline: boolean
   lastRecognizedText: string | null
+  hasMicPermission: boolean
 }
 
 interface VoiceActions {
   setRecognitionState: (state: VoiceRecognitionState) => void
   setIsOnline: (isOnline: boolean) => void
   setLastRecognizedText: (text: string | null) => void
+  setHasMicPermission: (hasPermission: boolean) => void
   resetVoice: () => void
 }
 
@@ -20,6 +22,7 @@ const INITIAL_VOICE_STATE: VoiceState = {
   recognitionState: VoiceRecognitionState.IDLE,
   isOnline: true,
   lastRecognizedText: null,
+  hasMicPermission: true,
 }
 
 export const useVoiceStore = create<VoiceStore>()((set) => ({
@@ -35,6 +38,10 @@ export const useVoiceStore = create<VoiceStore>()((set) => ({
 
   setLastRecognizedText: (text: string | null) => {
     set({ lastRecognizedText: text })
+  },
+
+  setHasMicPermission: (hasPermission: boolean) => {
+    set({ hasMicPermission: hasPermission })
   },
 
   resetVoice: () => {


### PR DESCRIPTION
## Summary
Share ExtensionのJSハンドラとURLスキームの実装。

## Changes
- **useShareHandler**: `autopl://import?url=...&name=...&size=...` を受信してimportFromUriに流す
  - コールドスタート（`Linking.getInitialURL`）とバックグラウンド再開（`addEventListener`）の両方に対応
- **app.json**: URLスキーム `autopl` を追加
- **App.tsx**: AppContentで`useShareHandler`を呼び出し

## iOS Native Setup（別途必要）
Share ExtensionはXcodeでのネイティブ設定が必要:
1. Xcodeで Share Extension ターゲットを追加
2. App Groups設定（`group.com.shogonakamura.autopl`）
3. Share ExtensionのInfo.plistでmp3/wav/m4aのNSExtensionActivationRule設定
4. ShareViewController.swiftで共有ファイルをApp Groupsコンテナにコピーし`openURL("autopl://import?...")`

## Test plan
- [ ] LINEで音声ファイルを受信 → 「共有」→ Autopl → インポートされる
- [ ] AirDropでm4aファイル受信 → Autopl選択 → インポートされる
- [ ] 非対応形式でバリデーションエラーになる

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)