### PR TITLE
[Fix] 音声認識: no-speechエラー表示の抑制とリスナー不安定動作を修正

### DIFF
--- a/src/hooks/useVoiceRecognition.ts
+++ b/src/hooks/useVoiceRecognition.ts
@@ -38,6 +38,12 @@ export const useVoiceRecognition = (
   const hasPermissionRef = useRef<boolean | null>(null)
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const isListeningRef = useRef(false)
+  const recognitionStateRef = useRef(recognitionState)
+
+  // recognitionStateRef を常に最新値に同期
+  useEffect(() => {
+    recognitionStateRef.current = recognitionState
+  }, [recognitionState])
 
   // ネットワーク状態の監視
   useEffect(() => {
@@ -163,14 +169,14 @@ export const useVoiceRecognition = (
         setLastRecognizedText(transcript)
 
         if (
-          recognitionState === VoiceRecognitionState.LISTENING_FOR_WAKEWORD
+          recognitionStateRef.current === VoiceRecognitionState.LISTENING_FOR_WAKEWORD
         ) {
           if (containsWakeWord(transcript)) {
             ExpoSpeechRecognitionModule.stop()
             startCommandListening()
           }
         } else if (
-          recognitionState === VoiceRecognitionState.LISTENING_FOR_COMMAND
+          recognitionStateRef.current === VoiceRecognitionState.LISTENING_FOR_COMMAND
         ) {
           const command = matchCommand(transcript)
           if (command && event.isFinal) {
@@ -193,7 +199,12 @@ export const useVoiceRecognition = (
     const errorSubscription = ExpoSpeechRecognitionModule.addListener(
       'error',
       (event) => {
-        console.error('[useVoiceRecognition] recognition error:', event.error)
+        // no-speech / speech-timeout はウェイクワード待機中の正常な挙動
+        if (event.error === 'no-speech' || event.error === 'speech-timeout') {
+          console.warn('[useVoiceRecognition] expected timeout:', event.error)
+        } else {
+          console.error('[useVoiceRecognition] recognition error:', event.error)
+        }
         // no-speech や speech-timeout の場合はリトライ
         if (
           isListeningRef.current &&
@@ -214,7 +225,7 @@ export const useVoiceRecognition = (
         // 認識が終了した場合、ウェイクワードモードなら再開
         if (
           isListeningRef.current &&
-          recognitionState === VoiceRecognitionState.LISTENING_FOR_WAKEWORD
+          recognitionStateRef.current === VoiceRecognitionState.LISTENING_FOR_WAKEWORD
         ) {
           setTimeout(() => {
             if (isListeningRef.current) {
@@ -230,8 +241,7 @@ export const useVoiceRecognition = (
       errorSubscription.remove()
       endSubscription.remove()
     }
-  }, [
-    recognitionState,
+  }, [ // eslint-disable-line react-hooks/exhaustive-deps
     containsWakeWord,
     matchCommand,
     startCommandListening,


### PR DESCRIPTION
## 問題

実機テスト中に以下の2つの問題が発生。

1. **赤エラーオーバーレイ**: ウェイクワード待機中に誰も話さないと `no-speech` エラーが `console.error` で出力され、開発画面に赤く表示される
2. **動作が不安定**: `recognitionState` を `useEffect` の依存配列に含めていたため、状態変化のたびにイベントリスナーが再登録され、イベント取りこぼしが発生

## 修正内容

- `recognitionStateRef` を追加し、イベントハンドラ内で `recognitionState` の代わりに `recognitionStateRef.current` を参照
- `recognitionState` を `useEffect` の依存配列から除外（リスナーの不要な再登録を防止）
- `no-speech` / `speech-timeout` は正常な挙動のため `console.error` → `console.warn` に変更

## Test plan
- [x] 既存テスト12件合格
- [ ] 実機でウェイクワード待機中に赤エラーが出ないことを確認
- [ ] ウェイクワード → コマンド認識の一連の動作が安定することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)