### PR TITLE
[Fix] soundServiceをexpo-avに戻しBluetooth不安定・audio-captureエラーを解消

### DIFF
--- a/__mocks__/expo-av.js
+++ b/__mocks__/expo-av.js
@@ -1,0 +1,17 @@
+const mockSound = {
+  playAsync: jest.fn().mockResolvedValue(undefined),
+  setPositionAsync: jest.fn().mockResolvedValue(undefined),
+  unloadAsync: jest.fn().mockResolvedValue(undefined),
+}
+
+const Audio = {
+  Sound: {
+    createAsync: jest.fn().mockResolvedValue({ sound: mockSound }),
+  },
+  setAudioModeAsync: jest.fn().mockResolvedValue(undefined),
+}
+
+const InterruptionModeIOS = { MixWithOthers: 0 }
+const InterruptionModeAndroid = { DuckOthers: 1 }
+
+module.exports = { Audio, InterruptionModeIOS, InterruptionModeAndroid }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@react-navigation/native": "^7.1.33",
         "@react-navigation/native-stack": "^7.14.4",
         "expo": "~55.0.5",
+        "expo-av": "^16.0.8",
         "expo-document-picker": "^55.0.8",
         "expo-file-system": "^55.0.10",
         "expo-speech-recognition": "^3.1.1",
@@ -6316,6 +6317,23 @@
           "optional": true
         },
         "react-native-webview": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/expo-av": {
+      "version": "16.0.8",
+      "resolved": "https://registry.npmjs.org/expo-av/-/expo-av-16.0.8.tgz",
+      "integrity": "sha512-cmVPftGR/ca7XBgs7R6ky36lF3OC0/MM/lpgX/yXqfv0jASTsh7AYX9JxHCwFmF+Z6JEB1vne9FDx4GiLcGreQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-web": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@react-navigation/native": "^7.1.33",
     "@react-navigation/native-stack": "^7.14.4",
     "expo": "~55.0.5",
+    "expo-av": "^16.0.8",
     "expo-document-picker": "^55.0.8",
     "expo-file-system": "^55.0.10",
     "expo-speech-recognition": "^3.1.1",

--- a/src/constants/sounds.ts
+++ b/src/constants/sounds.ts
@@ -1,4 +1,13 @@
 /**
+ * Feedback Sound File Paths
+ */
+export const SOUND_PATHS = {
+  WAKEWORD: require('../../assets/sounds/wakeword.mp3'),
+  SUCCESS: require('../../assets/sounds/success.mp3'),
+  FAILURE: require('../../assets/sounds/failure.mp3'),
+} as const
+
+/**
  * Sound Types
  */
 export enum SoundType {

--- a/src/services/__tests__/soundService.test.ts
+++ b/src/services/__tests__/soundService.test.ts
@@ -1,40 +1,32 @@
-import { soundService } from '../soundService'
 import { SoundType } from '../../constants/sounds'
 import { useSettingsStore } from '../../stores/settingsStore'
 
-// react-native-track-player をモック
-const mockAdd = jest.fn().mockResolvedValue(undefined)
-const mockSkip = jest.fn().mockResolvedValue(undefined)
-const mockRemove = jest.fn().mockResolvedValue(undefined)
-const mockSeekTo = jest.fn().mockResolvedValue(undefined)
-const mockGetQueue = jest.fn().mockResolvedValue([])
-const mockGetActiveTrackIndex = jest.fn().mockResolvedValue(undefined)
-const mockGetProgress = jest.fn().mockResolvedValue({ position: 0, duration: 0, buffered: 0 })
-
-const mockPlay = jest.fn().mockResolvedValue(undefined)
-const mockAddEventListener = jest.fn().mockImplementation((_event: unknown, callback: () => void) => {
-  // 即座にイベント発火して再生完了を通知
-  Promise.resolve().then(() => callback())
-  return { remove: jest.fn() }
+const mockPlayAsync = jest.fn().mockResolvedValue(undefined)
+const mockSetPositionAsync = jest.fn().mockResolvedValue(undefined)
+const mockUnloadAsync = jest.fn().mockResolvedValue(undefined)
+const mockCreateAsync = jest.fn().mockResolvedValue({
+  sound: {
+    playAsync: mockPlayAsync,
+    setPositionAsync: mockSetPositionAsync,
+    unloadAsync: mockUnloadAsync,
+  },
 })
+const mockSetAudioModeAsync = jest.fn().mockResolvedValue(undefined)
 
-jest.mock('react-native-track-player', () => ({
-  __esModule: true,
-  default: {
-    add: (...args: unknown[]) => mockAdd(...args),
-    skip: (...args: unknown[]) => mockSkip(...args),
-    play: (...args: unknown[]) => mockPlay(...args),
-    remove: (...args: unknown[]) => mockRemove(...args),
-    seekTo: (...args: unknown[]) => mockSeekTo(...args),
-    getQueue: () => mockGetQueue(),
-    getActiveTrackIndex: () => mockGetActiveTrackIndex(),
-    getProgress: () => mockGetProgress(),
-    addEventListener: (...args: unknown[]) => mockAddEventListener(...args),
+jest.mock('expo-av', () => ({
+  Audio: {
+    Sound: {
+      createAsync: (...args: unknown[]) => mockCreateAsync(...args),
+    },
+    setAudioModeAsync: (...args: unknown[]) => mockSetAudioModeAsync(...args),
   },
-  Event: {
-    PlaybackQueueEnded: 'playback-queue-ended',
-  },
+  InterruptionModeIOS: { MixWithOthers: 0 },
+  InterruptionModeAndroid: { DuckOthers: 1 },
 }))
+
+// soundService はモック設定後にインポートして最新状態を参照させる
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { soundService } = require('../soundService') as typeof import('../soundService')
 
 describe('soundService', () => {
   beforeEach(() => {
@@ -43,27 +35,41 @@ describe('soundService', () => {
   })
 
   describe('preload', () => {
-    it('TrackPlayerではプリロード不要のため何もしない', async () => {
+    it('オーディオモードをMixWithOthersで設定してサウンドをロードする', async () => {
       await soundService.preload()
-      expect(mockAdd).not.toHaveBeenCalled()
+
+      expect(mockSetAudioModeAsync).toHaveBeenCalledWith(
+        expect.objectContaining({ playsInSilentModeIOS: true })
+      )
+      expect(mockCreateAsync).toHaveBeenCalledTimes(3)
     })
   })
 
   describe('play', () => {
+    it('soundEnabledがtrueのとき再生する', async () => {
+      await soundService.preload()
+      await soundService.play(SoundType.WAKEWORD)
+
+      expect(mockSetPositionAsync).toHaveBeenCalledWith(0)
+      expect(mockPlayAsync).toHaveBeenCalled()
+    })
+
     it('soundEnabledがfalseのとき再生しない', async () => {
       useSettingsStore.getState().updateSettings({ soundEnabled: false })
 
+      await soundService.preload()
       await soundService.play(SoundType.WAKEWORD)
 
-      expect(mockAdd).not.toHaveBeenCalled()
-      expect(mockPlay).not.toHaveBeenCalled()
+      expect(mockPlayAsync).not.toHaveBeenCalled()
     })
   })
 
   describe('unload', () => {
-    it('TrackPlayerではアンロード不要のため何もしない', async () => {
+    it('ロード済みのサウンドをアンロードする', async () => {
+      await soundService.preload()
       await soundService.unload()
-      expect(mockRemove).not.toHaveBeenCalled()
+
+      expect(mockUnloadAsync).toHaveBeenCalledTimes(3)
     })
   })
 })

--- a/src/services/soundService.ts
+++ b/src/services/soundService.ts
@@ -1,30 +1,55 @@
-import TrackPlayer, { Event } from 'react-native-track-player'
-import { SoundType } from '../constants/sounds'
+import { Audio, InterruptionModeIOS, InterruptionModeAndroid } from 'expo-av'
+import { SoundType, SOUND_PATHS } from '../constants/sounds'
 import { useSettingsStore } from '../stores/settingsStore'
 
-/**
- * フィードバック音のファイルパスマッピング
- * TrackPlayer はローカルファイルを require() ではなくパスで扱うため、
- * assets にバンドルされた音声ファイルを参照する
- */
-const SOUND_URLS: Record<SoundType, string> = {
-  [SoundType.WAKEWORD]: 'asset:///wakeword.mp3',
-  [SoundType.SUCCESS]: 'asset:///success.mp3',
-  [SoundType.FAILURE]: 'asset:///failure.mp3',
+type SoundMap = Record<SoundType, Audio.Sound | null>
+
+const loadedSounds: SoundMap = {
+  [SoundType.WAKEWORD]: null,
+  [SoundType.SUCCESS]: null,
+  [SoundType.FAILURE]: null,
 }
 
-let isFeedbackPlaying = false
+const soundSources: Record<SoundType, number> = {
+  [SoundType.WAKEWORD]: SOUND_PATHS.WAKEWORD,
+  [SoundType.SUCCESS]: SOUND_PATHS.SUCCESS,
+  [SoundType.FAILURE]: SOUND_PATHS.FAILURE,
+}
 
 /**
  * フィードバック音サービス
- * react-native-track-player を使ってフィードバック音を再生する
+ * expo-av を使ってフィードバック音を再生する
+ *
+ * react-native-track-player（音楽再生）や expo-speech-recognition（音声認識）と
+ * 音声セッションを共有するため、InterruptionModeIOS.MixWithOthers を設定する。
+ * これにより Bluetooth プロファイルの切り替えを防ぎ、音楽再生・音声認識を中断しない。
  */
 export const soundService = {
   /**
-   * 音声ファイルをプリロードする（TrackPlayerでは不要だが互換性のため維持）
+   * 音声ファイルをプリロードする
    */
   async preload(): Promise<void> {
-    // TrackPlayer はトラック追加時にロードするためプリロード不要
+    try {
+      // MixWithOthers: TrackPlayer の音楽再生・expo-speech-recognition と共存させる
+      await Audio.setAudioModeAsync({
+        playsInSilentModeIOS: true,
+        staysActiveInBackground: false,
+        interruptionModeIOS: InterruptionModeIOS.MixWithOthers,
+        interruptionModeAndroid: InterruptionModeAndroid.DuckOthers,
+        shouldDuckAndroid: true,
+      })
+
+      for (const soundType of Object.values(SoundType)) {
+        if (!loadedSounds[soundType]) {
+          const { sound } = await Audio.Sound.createAsync(
+            soundSources[soundType]
+          )
+          loadedSounds[soundType] = sound
+        }
+      }
+    } catch (error) {
+      console.error('[SoundService] preload failed:', error)
+    }
   },
 
   /**
@@ -34,71 +59,33 @@ export const soundService = {
   async play(soundType: SoundType): Promise<void> {
     const soundEnabled = useSettingsStore.getState().soundEnabled
     if (!soundEnabled) return
-    if (isFeedbackPlaying) return
 
     try {
-      isFeedbackPlaying = true
-
-      // 現在のキューを保存して復元するのではなく、
-      // 短い効果音なのでキューの末尾に追加して再生後に削除する
-      const queue = await TrackPlayer.getQueue()
-      const currentTrackIndex = await TrackPlayer.getActiveTrackIndex()
-      const progress = await TrackPlayer.getProgress()
-
-      const feedbackTrack = {
-        id: `feedback-${soundType}-${Date.now()}`,
-        url: SOUND_URLS[soundType],
-        title: soundType,
-        artist: 'Autopl',
-      }
-
-      await TrackPlayer.add(feedbackTrack)
-      const newQueue = await TrackPlayer.getQueue()
-      await TrackPlayer.skip(newQueue.length - 1)
-      await TrackPlayer.play()
-
-      // 再生完了を待つ
-      await new Promise<void>((resolve) => {
-        const subscription = TrackPlayer.addEventListener(
-          Event.PlaybackQueueEnded,
-          () => {
-            subscription.remove()
-            resolve()
-          }
-        )
-        // 最大3秒でタイムアウト
-        setTimeout(() => {
-          subscription.remove()
-          resolve()
-        }, 3000)
-      })
-
-      // フィードバックトラックを削除して元の状態に復元
-      const updatedQueue = await TrackPlayer.getQueue()
-      const feedbackIndex = updatedQueue.findIndex(
-        (track) => track.id === feedbackTrack.id
-      )
-      if (feedbackIndex >= 0) {
-        await TrackPlayer.remove(feedbackIndex)
-      }
-
-      // 元のトラックに戻る
-      if (queue.length > 0 && currentTrackIndex !== undefined) {
-        await TrackPlayer.skip(currentTrackIndex)
-        await TrackPlayer.seekTo(progress.position)
+      const sound = loadedSounds[soundType]
+      if (sound) {
+        await sound.setPositionAsync(0)
+        await sound.playAsync()
       }
     } catch (error) {
       // フィードバック音の再生失敗はUIをブロックしない
       console.error('[SoundService] play failed:', error)
-    } finally {
-      isFeedbackPlaying = false
     }
   },
 
   /**
-   * リソースを解放する（TrackPlayerでは不要だが互換性のため維持）
+   * リソースを解放する
    */
   async unload(): Promise<void> {
-    // TrackPlayer のリソース解放は audioService.reset() で行う
+    for (const soundType of Object.values(SoundType)) {
+      try {
+        const sound = loadedSounds[soundType]
+        if (sound) {
+          await sound.unloadAsync()
+          loadedSounds[soundType] = null
+        }
+      } catch (error) {
+        console.error('[SoundService] unload failed:', error)
+      }
+    }
   },
 }


### PR DESCRIPTION
## 問題

実機テストで以下の2つの問題が発生。

1. **`audio-capture` エラー**: 音声認識がコマンド聞き取りフェーズに到達できない
2. **Bluetooth高速切り替え・音楽停止**: フィードバック音再生のたびに接続が不安定になる

## 原因

PR #47 で `soundService` を `expo-av` → `react-native-track-player` に移行したことが原因。
フィードバック音再生のたびに TrackPlayer のキュー操作（`skip`/`add`/`remove`）が発生し、
Bluetooth が A2DP ⇔ HFP 間で高速切り替えを起こしていた。

## 修正

- `soundService` を `expo-av` に戻す
- `InterruptionModeIOS.MixWithOthers` を設定し、TrackPlayer と expo-speech-recognition と音声セッションを共存
- `expo-av` を `package.json` に追加（以前から使用されていたが未登録だった）
- Jest グローバルモック（`__mocks__/expo-av.js`）を追加してテストを修正

## Test plan
- [x] 全120テスト合格
- [ ] 実機でBluetooth切り替えが発生しないことを確認
- [ ] 実機でaudio-captureエラーが解消されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)