### PR TITLE
[Fix] expo-audioプラグインをapp.jsonに追加（TurboModuleManagerタイムアウト修正）

### DIFF
--- a/app.json
+++ b/app.json
@@ -27,7 +27,8 @@
           "microphonePermission": "音声コマンドでの操作に使用します。",
           "speechRecognitionPermission": "音声コマンドを認識するために使用します。"
         }
-      ]
+      ],
+      "expo-audio"
     ],
     "scheme": "autopl",
     "web": {


### PR DESCRIPTION
## 問題

アプリが起動時にクラッシュする。

```
TurboModuleManager: Timed out waiting for modules to be invalidated
```

## 原因

PR #49 で `expo-audio` を追加した際、`npx expo install expo-audio` が自動追加した `app.json` の configプラグイン設定がコミット漏れになっていた。

このプラグインがないと `expo-audio` の iOS native モジュールが正しく初期化されず、TurboModuleManager がタイムアウトしてクラッシュする。

## 修正

`app.json` の `plugins` に `"expo-audio"` を追加。

## マージ後の手順

```bash
npx pod-install
npx expo run:ios --device
```

Closes #49 の後続対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)