### PR TITLE
[Fix] Bluetooth接続時のオーディオルート高速切り替えを修正

### DIFF
--- a/src/services/audioService.ts
+++ b/src/services/audioService.ts
@@ -1,6 +1,9 @@
 import TrackPlayer, {
   Capability,
   AppKilledPlaybackBehavior,
+  IOSCategory,
+  IOSCategoryMode,
+  IOSCategoryOptions,
 } from 'react-native-track-player'
 
 let isPlayerSetup = false
@@ -17,7 +20,19 @@ export const audioService = {
     if (isPlayerSetup) return
 
     try {
-      await TrackPlayer.setupPlayer()
+      // PlayAndRecord + AllowBluetoothA2DP のみ指定することで、
+      // Bluetooth デバイスは A2DP（高音質）のまま維持し、
+      // マイク入力は内蔵マイクを使用する。
+      // AllowBluetooth（HFP）は指定しないことで、音声認識開始時に
+      // Bluetooth プロファイルが A2DP → HFP に切り替わるのを防ぐ。
+      await TrackPlayer.setupPlayer({
+        iosCategory: IOSCategory.PlayAndRecord,
+        iosCategoryMode: IOSCategoryMode.Default,
+        iosCategoryOptions: [
+          IOSCategoryOptions.AllowBluetoothA2DP,
+          IOSCategoryOptions.DefaultToSpeaker,
+        ],
+      })
       await TrackPlayer.updateOptions({
         capabilities: [
           Capability.Play,

--- a/src/services/soundService.ts
+++ b/src/services/soundService.ts
@@ -31,10 +31,14 @@ export const soundService = {
    */
   async preload(): Promise<void> {
     try {
+      // allowsRecording: true にすることで TrackPlayer の PlayAndRecord
+      // カテゴリ設定と競合しないようにする。
+      // （false のままだと expo-audio が Playback カテゴリに戻してしまい
+      //   音声認識時に Bluetooth プロファイルが切り替わる原因になる）
       await setAudioModeAsync({
         playsInSilentMode: true,
         interruptionMode: 'mixWithOthers',
-        allowsRecording: false,
+        allowsRecording: true,
         shouldPlayInBackground: false,
         shouldRouteThroughEarpiece: false,
       })


### PR DESCRIPTION
## Summary

- TrackPlayerのiOS音声セッションを`PlayAndRecord` + `AllowBluetoothA2DP`に設定し、Bluetooth接続時のA2DP↔HFPプロファイル高速切り替えを防止
- soundServiceの`allowsRecording`を`true`に変更し、expo-audioが音声セッションを`Playback`カテゴリに戻す競合を解消
- 内蔵マイクを音声認識に使用し、Bluetoothデバイスは常にA2DP（高音質）のまま維持

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `src/services/audioService.ts` | `setupPlayer()`にiOS音声セッション設定を追加（PlayAndRecord + AllowBluetoothA2DP + DefaultToSpeaker） |
| `src/services/soundService.ts` | `allowsRecording`を`true`に変更 |

## 原因

Bluetooth接続時、`expo-speech-recognition`のウェイクワード検出がiOSの音声セッションをHFP（通話品質）に切り替えていた。約20秒の無音タイムアウト後に認識が再起動するたびにA2DP↔HFPが高速で切り替わり、音楽再生が破綻していた。

## Test plan

- [ ] Bluetoothイヤホン接続時に音楽を再生し、20秒以上正常に再生が続くことを確認
- [ ] Bluetoothスピーカー接続時に音楽を再生し、同様に確認
- [ ] 音声認識（ウェイクワード検出）を有効にした状態でBluetooth再生が安定することを確認
- [ ] Bluetooth未接続時にスピーカーから正常に再生されることを確認
- [ ] フィードバック音（ウェイクワード検出音など）が正常に鳴ることを確認

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)