### PR TITLE
[Frontend] 設定画面にマイク・スピーカーデバイス選択機能を追加

### DIFF
--- a/modules/audio-route/expo-module.config.json
+++ b/modules/audio-route/expo-module.config.json
@@ -1,0 +1,6 @@
+{
+  "platforms": ["ios"],
+  "ios": {
+    "modules": ["AudioRouteModule"]
+  }
+}

--- a/modules/audio-route/index.ts
+++ b/modules/audio-route/index.ts
@@ -1,0 +1,26 @@
+import { requireNativeModule } from 'expo-modules-core'
+
+const AudioRouteNativeModule = requireNativeModule('AudioRoute')
+
+export interface AudioPort {
+  uid: string
+  name: string
+  type: string
+}
+
+export const getAvailableInputs = (): Promise<AudioPort[]> =>
+  AudioRouteNativeModule.getAvailableInputs()
+
+export const getAvailableOutputs = (): Promise<AudioPort[]> =>
+  AudioRouteNativeModule.getAvailableOutputs()
+
+export const setPreferredInput = (uid: string | null): Promise<void> =>
+  AudioRouteNativeModule.setPreferredInput(uid)
+
+export const setPreferredOutput = (uid: string): Promise<void> =>
+  AudioRouteNativeModule.setPreferredOutput(uid)
+
+export const getCurrentRoute = (): Promise<{
+  inputs: AudioPort[]
+  outputs: AudioPort[]
+}> => AudioRouteNativeModule.getCurrentRoute()

--- a/modules/audio-route/package.json
+++ b/modules/audio-route/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "audio-route",
+  "version": "1.0.0",
+  "main": "index"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@react-navigation/drawer": "^7.9.4",
         "@react-navigation/native": "^7.1.33",
         "@react-navigation/native-stack": "^7.14.4",
+        "audio-route": "file:./modules/audio-route",
         "expo": "~55.0.5",
         "expo-audio": "~55.0.8",
         "expo-document-picker": "^55.0.8",
@@ -40,6 +41,9 @@
         "ts-jest": "^29.4.6",
         "typescript": "~5.9.2"
       }
+    },
+    "modules/audio-route": {
+      "version": "1.0.0"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -4942,6 +4946,10 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/audio-route": {
+      "resolved": "modules/audio-route",
+      "link": true
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "react-native-screens": "^4.24.0",
     "react-native-track-player": "^4.1.2",
     "react-native-worklets": "^0.7.4",
-    "zustand": "^5.0.11"
+    "zustand": "^5.0.11",
+    "audio-route": "file:./modules/audio-route"
   },
   "devDependencies": {
     "@testing-library/react-native": "^13.3.3",

--- a/src/components/settings/AudioDevicePicker.tsx
+++ b/src/components/settings/AudioDevicePicker.tsx
@@ -1,0 +1,94 @@
+import React, { useState } from 'react'
+import { StyleSheet, View } from 'react-native'
+import { Menu, Text, TouchableRipple, useTheme } from 'react-native-paper'
+import type { AudioPort } from '../../../modules/audio-route'
+
+interface Props {
+  icon: string
+  selectedUID: string | null
+  devices: AudioPort[]
+  onSelect: (uid: string) => void
+  accessibilityLabel: string
+}
+
+export const AudioDevicePicker: React.FC<Props> = ({
+  icon,
+  selectedUID,
+  devices,
+  onSelect,
+  accessibilityLabel,
+}) => {
+  const { colors } = useTheme()
+  const [menuVisible, setMenuVisible] = useState(false)
+
+  const selectedDevice = devices.find((d) => d.uid === selectedUID) ?? devices[0]
+
+  if (devices.length === 0) return null
+
+  return (
+    <Menu
+      visible={menuVisible}
+      onDismiss={() => setMenuVisible(false)}
+      anchor={
+        <TouchableRipple
+          onPress={() => setMenuVisible(true)}
+          style={[
+            styles.picker,
+            {
+              borderColor: colors.outline,
+              backgroundColor: colors.surfaceVariant,
+            },
+          ]}
+          accessibilityLabel={accessibilityLabel}
+          borderless={false}
+        >
+          <View style={styles.pickerContent}>
+            <Text
+              variant="bodyMedium"
+              style={[styles.deviceName, { color: colors.onSurface }]}
+              numberOfLines={1}
+            >
+              {icon} {selectedDevice?.name ?? '—'}
+            </Text>
+            <Text variant="bodyMedium" style={{ color: colors.onSurfaceVariant }}>
+              ▼
+            </Text>
+          </View>
+        </TouchableRipple>
+      }
+    >
+      {devices.map((device) => (
+        <Menu.Item
+          key={device.uid}
+          title={device.name}
+          onPress={() => {
+            onSelect(device.uid)
+            setMenuVisible(false)
+          }}
+          leadingIcon={
+            device.uid === (selectedUID ?? devices[0]?.uid) ? 'check' : undefined
+          }
+        />
+      ))}
+    </Menu>
+  )
+}
+
+const styles = StyleSheet.create({
+  picker: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    flex: 1,
+  },
+  pickerContent: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: 8,
+  },
+  deviceName: {
+    flex: 1,
+  },
+})

--- a/src/constants/defaults.ts
+++ b/src/constants/defaults.ts
@@ -76,4 +76,5 @@ export const STORAGE_KEYS = {
   SELECTED_FILE_ID: 'selected_file_id',
   SETTINGS: 'settings',
   ONBOARDING_DONE: 'onboarding_done',
+  AUDIO_DEVICE: 'audio_device',
 } as const

--- a/src/hooks/useAudioDeviceRoute.ts
+++ b/src/hooks/useAudioDeviceRoute.ts
@@ -1,0 +1,90 @@
+import { useCallback, useEffect, useState } from 'react'
+import { AppState } from 'react-native'
+import * as AudioRoute from '../../modules/audio-route'
+import type { AudioPort } from '../../modules/audio-route'
+import { useAudioDeviceStore } from '../stores/audioDeviceStore'
+
+export const useAudioDeviceRoute = () => {
+  const [availableInputs, setAvailableInputs] = useState<AudioPort[]>([])
+  const [availableOutputs, setAvailableOutputs] = useState<AudioPort[]>([])
+
+  const preferredInputUID = useAudioDeviceStore((state) => state.preferredInputUID)
+  const preferredOutputUID = useAudioDeviceStore((state) => state.preferredOutputUID)
+  const isManuallySet = useAudioDeviceStore((state) => state.isManuallySet)
+  const storeSetPreferredInput = useAudioDeviceStore((state) => state.setPreferredInput)
+  const storeSetPreferredOutput = useAudioDeviceStore((state) => state.setPreferredOutput)
+
+  const refreshDevices = useCallback(async () => {
+    try {
+      const [inputs, outputs] = await Promise.all([
+        AudioRoute.getAvailableInputs(),
+        AudioRoute.getAvailableOutputs(),
+      ])
+      setAvailableInputs(inputs)
+      setAvailableOutputs(outputs)
+    } catch (error) {
+      console.error('[useAudioDeviceRoute] refreshDevices failed:', error)
+    }
+  }, [])
+
+  const applyPreferences = useCallback(async () => {
+    try {
+      await AudioRoute.setPreferredInput(preferredInputUID)
+      if (preferredOutputUID) {
+        await AudioRoute.setPreferredOutput(preferredOutputUID)
+      }
+    } catch (error) {
+      console.error('[useAudioDeviceRoute] applyPreferences failed:', error)
+    }
+  }, [preferredInputUID, preferredOutputUID])
+
+  useEffect(() => {
+    refreshDevices()
+    applyPreferences()
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // フォアグラウンド復帰時にデバイス一覧を再スキャン
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', (nextState) => {
+      if (nextState === 'active') {
+        refreshDevices()
+      }
+    })
+    return () => subscription.remove()
+  }, [refreshDevices])
+
+  const selectInput = useCallback(
+    async (uid: string) => {
+      try {
+        await AudioRoute.setPreferredInput(uid)
+        storeSetPreferredInput(uid)
+      } catch (error) {
+        console.error('[useAudioDeviceRoute] selectInput failed:', error)
+      }
+    },
+    [storeSetPreferredInput]
+  )
+
+  const selectOutput = useCallback(
+    async (uid: string) => {
+      try {
+        await AudioRoute.setPreferredOutput(uid)
+        storeSetPreferredOutput(uid)
+      } catch (error) {
+        console.error('[useAudioDeviceRoute] selectOutput failed:', error)
+      }
+    },
+    [storeSetPreferredOutput]
+  )
+
+  return {
+    availableInputs,
+    availableOutputs,
+    preferredInputUID,
+    preferredOutputUID,
+    isManuallySet,
+    selectInput,
+    selectOutput,
+    refreshDevices,
+  }
+}

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -13,6 +13,8 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack'
 import { RootStackParamList } from '../navigation/types'
 import { VoiceCommand } from '../types'
 import { useSettingsStore } from '../stores/settingsStore'
+import { useAudioDeviceRoute } from '../hooks/useAudioDeviceRoute'
+import { AudioDevicePicker } from '../components/settings/AudioDevicePicker'
 import {
   validateWakeWord,
   validateCommandWord,
@@ -55,6 +57,15 @@ const INITIAL_ERRORS: FieldErrors = {
 
 export const SettingsScreen: React.FC<Props> = ({ navigation }) => {
   const { colors } = useTheme()
+
+  const {
+    availableInputs,
+    availableOutputs,
+    preferredInputUID,
+    preferredOutputUID,
+    selectInput,
+    selectOutput,
+  } = useAudioDeviceRoute()
 
   const storeWakeWord = useSettingsStore((state) => state.wakeWord)
   const storeCommands = useSettingsStore((state) => state.commands)
@@ -162,6 +173,33 @@ export const SettingsScreen: React.FC<Props> = ({ navigation }) => {
         style={styles.scrollView}
         contentContainerStyle={styles.scrollContent}
       >
+        <Text
+          variant="titleMedium"
+          style={[styles.sectionTitle, { color: colors.primary }]}
+        >
+          オーディオデバイス
+        </Text>
+        <View style={styles.deviceRow}>
+          <AudioDevicePicker
+            icon="🎤"
+            selectedUID={preferredInputUID}
+            devices={availableInputs}
+            onSelect={selectInput}
+            accessibilityLabel="マイクデバイスを選択"
+          />
+        </View>
+        <View style={[styles.deviceRow, { marginTop: 8 }]}>
+          <AudioDevicePicker
+            icon="🔊"
+            selectedUID={preferredOutputUID}
+            devices={availableOutputs}
+            onSelect={selectOutput}
+            accessibilityLabel="スピーカーデバイスを選択"
+          />
+        </View>
+
+        <Divider style={styles.divider} />
+
         <Text
           variant="titleMedium"
           style={[styles.sectionTitle, { color: colors.primary }]}
@@ -304,5 +342,8 @@ const styles = StyleSheet.create({
   },
   saveButton: {
     marginTop: 8,
+  },
+  deviceRow: {
+    flexDirection: 'row',
   },
 })

--- a/src/stores/audioDeviceStore.ts
+++ b/src/stores/audioDeviceStore.ts
@@ -1,0 +1,43 @@
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { STORAGE_KEYS } from '../constants/defaults'
+
+interface AudioDeviceState {
+  preferredInputUID: string | null
+  preferredOutputUID: string | null
+  isManuallySet: boolean
+}
+
+interface AudioDeviceActions {
+  setPreferredInput: (uid: string | null) => void
+  setPreferredOutput: (uid: string | null) => void
+  resetToAuto: () => void
+}
+
+export const useAudioDeviceStore = create<AudioDeviceState & AudioDeviceActions>()(
+  persist(
+    (set) => ({
+      preferredInputUID: null,
+      preferredOutputUID: null,
+      isManuallySet: false,
+
+      setPreferredInput: (uid) =>
+        set({ preferredInputUID: uid, isManuallySet: true }),
+
+      setPreferredOutput: (uid) =>
+        set({ preferredOutputUID: uid, isManuallySet: true }),
+
+      resetToAuto: () =>
+        set({
+          preferredInputUID: null,
+          preferredOutputUID: null,
+          isManuallySet: false,
+        }),
+    }),
+    {
+      name: STORAGE_KEYS.AUDIO_DEVICE,
+      storage: createJSONStorage(() => AsyncStorage),
+    }
+  )
+)


### PR DESCRIPTION
## Summary

- Bluetooth/有線接続時のオーディオルート問題を根本解決するため、設定画面の最上部にマイク（入力）とスピーカー（出力）を明示的に選択できるUIを追加
- iOS の `AVAudioSession` を操作する Expo ネイティブモジュール `audio-route` を新規作成
- 手動設定後は自動切り替えせず、選択状態を AsyncStorage に永続化

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `modules/audio-route/ios/AudioRouteModule.swift` | 新規：AVAudioSession を操作するネイティブモジュール |
| `modules/audio-route/index.ts` | 新規：JS/TS バインディング |
| `modules/audio-route/expo-module.config.json` | 新規：Expo モジュール設定 |
| `src/stores/audioDeviceStore.ts` | 新規：デバイス選択の永続化ストア |
| `src/hooks/useAudioDeviceRoute.ts` | 新規：デバイス一覧取得・適用・再スキャン |
| `src/components/settings/AudioDevicePicker.tsx` | 新規：ドロップダウン選択 UI |
| `src/screens/SettingsScreen.tsx` | 変更：最上部にデバイス選択セクション追加 |
| `src/constants/defaults.ts` | 変更：`STORAGE_KEYS.AUDIO_DEVICE` 追加 |
| `package.json` | 変更：`audio-route` ローカルモジュールを依存に追加 |

## 列挙される出力デバイス

| デバイス種別 | 表示例 |
|---|---|
| Bluetooth A2DP | EarFun Air Pro 4 |
| 有線 3.5mm | Headphones |
| USB-C 接続 | DELL S2722QC |
| 内蔵スピーカー | 内蔵スピーカー（常に表示） |

## ⚠️ ビルド手順（マージ後の確認）

ネイティブモジュールを追加したため、`expo prebuild` が必要です：

```bash
npx expo prebuild --clean
npx expo run:ios --device
```

## Test plan

- [ ] 設定画面の最上部に「オーディオデバイス」セクションが表示される
- [ ] Bluetooth イヤホン接続時、マイク一覧に「内蔵マイク」と「Bluetooth マイク」が表示される
- [ ] USB-C スピーカー接続時、出力一覧にデバイス名が表示される
- [ ] デバイス選択後、選択状態がアプリ再起動後も保持される
- [ ] マイクとして Bluetooth を選択し音楽再生しても A2DP が維持される（#51 の確認）
- [ ] バックグラウンドから復帰するとデバイス一覧が再スキャンされる

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)