### PR TITLE
[Fix] AudioRouteネイティブモジュールのPodspecを追加しデバイスピッカーを修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@ expo-env.d.ts
 ios/
 android/
 
+# Allow local native modules' ios/ directories
+!modules/*/ios/
+!modules/*/ios/**
+
 # Environment variables
 .env
 .env.local

--- a/modules/audio-route/expo-module.config.json
+++ b/modules/audio-route/expo-module.config.json
@@ -1,6 +1,7 @@
 {
-  "platforms": ["ios"],
-  "ios": {
-    "modules": ["AudioRouteModule"]
+  "platforms": ["apple"],
+  "apple": {
+    "modules": ["AudioRouteModule"],
+    "podspecPath": "ios/AudioRoute.podspec"
   }
 }

--- a/modules/audio-route/ios/AudioRoute.podspec
+++ b/modules/audio-route/ios/AudioRoute.podspec
@@ -1,0 +1,26 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name           = 'AudioRoute'
+  s.version        = package['version']
+  s.summary        = 'iOS AVAudioSession route management module'
+  s.description    = 'Expo native module for querying and setting iOS audio input/output routes'
+  s.license        = { :type => 'MIT' }
+  s.author         = 'autopl'
+  s.homepage       = 'https://github.com/shogonakamura1/autopl'
+  s.platforms      = { :ios => '15.1' }
+  s.swift_version  = '5.9'
+  s.source         = { :git => '' }
+  s.static_framework = true
+
+  s.dependency 'ExpoModulesCore'
+
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+    'SWIFT_COMPILATION_MODE' => 'wholemodule'
+  }
+
+  s.source_files = '*.swift'
+end

--- a/modules/audio-route/ios/AudioRouteModule.swift
+++ b/modules/audio-route/ios/AudioRouteModule.swift
@@ -1,0 +1,101 @@
+import ExpoModulesCore
+import AVFoundation
+
+public class AudioRouteModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("AudioRoute")
+
+    // 接続済み入力デバイス（マイク）一覧を返す
+    AsyncFunction("getAvailableInputs") { () -> [[String: String]] in
+      guard let inputs = AVAudioSession.sharedInstance().availableInputs else {
+        return []
+      }
+      return inputs.map { port in
+        [
+          "uid": port.uid,
+          "name": port.portName,
+          "type": port.portType.rawValue,
+        ]
+      }
+    }
+
+    // 利用可能な出力デバイス一覧を返す
+    // 内蔵スピーカーは常に含める。現在接続中の外部デバイス（Bluetooth/有線）も列挙。
+    AsyncFunction("getAvailableOutputs") { () -> [[String: String]] in
+      var outputs: [[String: String]] = []
+
+      // 現在のルートの出力ポートを追加（接続中の外部デバイス）
+      let currentOutputs = AVAudioSession.sharedInstance().currentRoute.outputs
+      for port in currentOutputs {
+        if port.portType != .builtInSpeaker {
+          outputs.append([
+            "uid": port.uid,
+            "name": port.portName,
+            "type": port.portType.rawValue,
+          ])
+        }
+      }
+
+      // 内蔵スピーカーは常に選択肢として末尾に追加
+      outputs.append([
+        "uid": "builtin_speaker",
+        "name": "内蔵スピーカー",
+        "type": AVAudioSession.Port.builtInSpeaker.rawValue,
+      ])
+
+      return outputs
+    }
+
+    // 優先する入力デバイス（マイク）を設定する。nil で自動に戻す。
+    AsyncFunction("setPreferredInput") { (uid: String?) throws in
+      let session = AVAudioSession.sharedInstance()
+
+      guard let uid = uid else {
+        try session.setPreferredInput(nil)
+        return
+      }
+
+      guard let inputs = session.availableInputs,
+            let port = inputs.first(where: { $0.uid == uid }) else {
+        // 指定ポートが見つからない場合は自動に戻す（エラーにしない）
+        try session.setPreferredInput(nil)
+        return
+      }
+
+      try session.setPreferredInput(port)
+    }
+
+    // 優先する出力デバイスを設定する。
+    // "builtin_speaker" → 内蔵スピーカーを強制。
+    // その他の uid → 接続中のデバイスを使用（iOS のルーティングに委ねる）。
+    AsyncFunction("setPreferredOutput") { (uid: String) throws in
+      let session = AVAudioSession.sharedInstance()
+
+      if uid == "builtin_speaker" {
+        try session.overrideOutputAudioPort(.speaker)
+      } else {
+        try session.overrideOutputAudioPort(.none)
+      }
+    }
+
+    // 現在アクティブなルート（入出力）を返す
+    AsyncFunction("getCurrentRoute") { () -> [String: [[String: String]]] in
+      let session = AVAudioSession.sharedInstance()
+      let inputs = session.currentRoute.inputs.map { port in
+        [
+          "uid": port.uid,
+          "name": port.portName,
+          "type": port.portType.rawValue,
+        ]
+      }
+      let outputs = session.currentRoute.outputs.map { port in
+        [
+          "uid": port.uid,
+          "name": port.portName,
+          "type": port.portType.rawValue,
+        ]
+      }
+      return ["inputs": inputs, "outputs": outputs]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `modules/audio-route/ios/AudioRoute.podspec` を追加し、`use_expo_modules!` が CocoaPods ビルドに `AudioRouteModule` を含めるようにした
- `expo-module.config.json` に `podspecPath` を明示的に指定
- `.gitignore` に `!modules/*/ios/` の否定パターンを追加し、ネイティブモジュールの `ios/` ディレクトリが誤って無視されていた問題を修正

## Root Cause

`.gitignore` の `ios/` パターンが `modules/audio-route/ios/` ディレクトリにもマッチしていたため、`AudioRoute.podspec` をコミットできず、CocoaPods がモジュールを認識できなかった。

## Test plan

- [ ] `npx expo prebuild --clean` を実行
- [ ] `cd ios && pod install && cd ..` を実行（`AudioRoute` が Pods に含まれることを確認）
- [ ] Xcode でビルドしてiPhone実機にインストール
- [ ] 設定画面を開き、マイク・スピーカーのデバイスピッカーが表示されることを確認
- [ ] Bluetooth/有線デバイスを選択できることを確認

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)