### PR TITLE
[Frontend] オーディオデバイスピッカーUIをピル型横並びに再設計

### DIFF
--- a/modules/audio-route/ios/AudioRouteModule.swift
+++ b/modules/audio-route/ios/AudioRouteModule.swift
@@ -6,10 +6,25 @@ public class AudioRouteModule: Module {
     Name("AudioRoute")
 
     // 接続済み入力デバイス（マイク）一覧を返す
+    // Bluetoothデバイスを列挙するために一時的に .allowBluetooth を付与してから元に戻す
     AsyncFunction("getAvailableInputs") { () -> [[String: String]] in
-      guard let inputs = AVAudioSession.sharedInstance().availableInputs else {
-        return []
+      let session = AVAudioSession.sharedInstance()
+      let originalOptions = session.categoryOptions
+
+      // .allowBluetooth がない場合は一時付与（BluetoothマイクがavailableInputsに出ない対策）
+      if !originalOptions.contains(.allowBluetooth) {
+        try? session.setCategory(session.category, mode: session.mode,
+                                  options: originalOptions.union(.allowBluetooth))
       }
+
+      let inputs = session.availableInputs ?? []
+
+      // 元のオプションに戻す
+      if !originalOptions.contains(.allowBluetooth) {
+        try? session.setCategory(session.category, mode: session.mode,
+                                  options: originalOptions)
+      }
+
       return inputs.map { port in
         [
           "uid": port.uid,

--- a/src/components/settings/AudioDevicePicker.tsx
+++ b/src/components/settings/AudioDevicePicker.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from 'react'
 import { StyleSheet, View } from 'react-native'
-import { Menu, Text, TouchableRipple, useTheme } from 'react-native-paper'
+import { Icon, Menu, Text, TouchableRipple, useTheme } from 'react-native-paper'
 import type { AudioPort } from '../../../modules/audio-route'
 
 interface Props {
-  icon: string
+  iconName: string
   selectedUID: string | null
   devices: AudioPort[]
   onSelect: (uid: string) => void
@@ -12,7 +12,7 @@ interface Props {
 }
 
 export const AudioDevicePicker: React.FC<Props> = ({
-  icon,
+  iconName,
   selectedUID,
   devices,
   onSelect,
@@ -33,7 +33,7 @@ export const AudioDevicePicker: React.FC<Props> = ({
         <TouchableRipple
           onPress={() => setMenuVisible(true)}
           style={[
-            styles.picker,
+            styles.pill,
             {
               borderColor: colors.outline,
               backgroundColor: colors.surfaceVariant,
@@ -42,17 +42,17 @@ export const AudioDevicePicker: React.FC<Props> = ({
           accessibilityLabel={accessibilityLabel}
           borderless={false}
         >
-          <View style={styles.pickerContent}>
+          <View style={styles.pillContent}>
+            <Icon source={iconName} size={14} color={colors.onSurfaceVariant} />
             <Text
-              variant="bodyMedium"
+              variant="bodySmall"
               style={[styles.deviceName, { color: colors.onSurface }]}
               numberOfLines={1}
+              ellipsizeMode="tail"
             >
-              {icon} {selectedDevice?.name ?? '—'}
+              {selectedDevice?.name ?? '—'}
             </Text>
-            <Text variant="bodyMedium" style={{ color: colors.onSurfaceVariant }}>
-              ▼
-            </Text>
+            <Icon source="chevron-down" size={14} color={colors.onSurfaceVariant} />
           </View>
         </TouchableRipple>
       }
@@ -75,18 +75,18 @@ export const AudioDevicePicker: React.FC<Props> = ({
 }
 
 const styles = StyleSheet.create({
-  picker: {
-    borderWidth: 1,
-    borderRadius: 8,
-    paddingHorizontal: 12,
-    paddingVertical: 10,
+  pill: {
     flex: 1,
+    borderWidth: 1.5,
+    borderRadius: 100,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    overflow: 'hidden',
   },
-  pickerContent: {
+  pillContent: {
     flexDirection: 'row',
-    justifyContent: 'space-between',
     alignItems: 'center',
-    gap: 8,
+    gap: 6,
   },
   deviceName: {
     flex: 1,

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -181,16 +181,14 @@ export const SettingsScreen: React.FC<Props> = ({ navigation }) => {
         </Text>
         <View style={styles.deviceRow}>
           <AudioDevicePicker
-            icon="🎤"
+            iconName="microphone"
             selectedUID={preferredInputUID}
             devices={availableInputs}
             onSelect={selectInput}
             accessibilityLabel="マイクデバイスを選択"
           />
-        </View>
-        <View style={[styles.deviceRow, { marginTop: 8 }]}>
           <AudioDevicePicker
-            icon="🔊"
+            iconName="volume-high"
             selectedUID={preferredOutputUID}
             devices={availableOutputs}
             onSelect={selectOutput}
@@ -345,5 +343,6 @@ const styles = StyleSheet.create({
   },
   deviceRow: {
     flexDirection: 'row',
+    gap: 8,
   },
 })


### PR DESCRIPTION
## Summary

- `AudioDevicePicker` をピル型（`borderRadius: 100`）に再設計し、画像のChrome風デバイスピッカーに合わせたUIに変更
- マイク・スピーカーの2つのピッカーを同一行に横並び配置（`gap: 8`）
- デバイス名は `numberOfLines={1}` + `ellipsizeMode="tail"` で固定幅トランケート表示
- 絵文字アイコンを `react-native-paper` の `Icon`（MaterialCommunityIcons）に置き換え
- `AudioRouteModule.swift` の `getAvailableInputs()` を修正：一時的に `.allowBluetooth` を付与してBluetoothデバイスを `availableInputs` に列挙し、その後元のオプションに戻す

## Test plan

- [ ] 設定画面を開き、マイク・スピーカーピッカーが同じ行に横並びで表示される
- [ ] デバイス名が長い場合に `...` でトランケートされる
- [ ] マイクピッカーの選択肢にBluetoothデバイスが表示される
- [ ] 各ピッカーをタップしてデバイスを選択できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)