### PR TITLE
[Fix] デバイスピッカーUX・コマンド遅延・音楽途切れを修正

### DIFF
--- a/src/components/settings/AudioDevicePicker.tsx
+++ b/src/components/settings/AudioDevicePicker.tsx
@@ -25,58 +25,64 @@ export const AudioDevicePicker: React.FC<Props> = ({
 
   if (devices.length === 0) return null
 
+  // react-native-paper の Menu は anchor を内部 View で包むため、
+  // flex: 1 を効かせるには外側の View が必要
   return (
-    <Menu
-      visible={menuVisible}
-      onDismiss={() => setMenuVisible(false)}
-      anchor={
-        <TouchableRipple
-          onPress={() => setMenuVisible(true)}
-          style={[
-            styles.pill,
-            {
-              borderColor: colors.outline,
-              backgroundColor: colors.surfaceVariant,
-            },
-          ]}
-          accessibilityLabel={accessibilityLabel}
-          borderless={false}
-        >
-          <View style={styles.pillContent}>
-            <Icon source={iconName} size={14} color={colors.onSurfaceVariant} />
-            <Text
-              variant="bodySmall"
-              style={[styles.deviceName, { color: colors.onSurface }]}
-              numberOfLines={1}
-              ellipsizeMode="tail"
-            >
-              {selectedDevice?.name ?? '—'}
-            </Text>
-            <Icon source="chevron-down" size={14} color={colors.onSurfaceVariant} />
-          </View>
-        </TouchableRipple>
-      }
-    >
-      {devices.map((device) => (
-        <Menu.Item
-          key={device.uid}
-          title={device.name}
-          onPress={() => {
-            onSelect(device.uid)
-            setMenuVisible(false)
-          }}
-          leadingIcon={
-            device.uid === (selectedUID ?? devices[0]?.uid) ? 'check' : undefined
-          }
-        />
-      ))}
-    </Menu>
+    <View style={styles.wrapper}>
+      <Menu
+        visible={menuVisible}
+        onDismiss={() => setMenuVisible(false)}
+        anchor={
+          <TouchableRipple
+            onPress={() => setMenuVisible(true)}
+            style={[
+              styles.pill,
+              {
+                borderColor: colors.outline,
+                backgroundColor: colors.surfaceVariant,
+              },
+            ]}
+            accessibilityLabel={accessibilityLabel}
+            borderless={false}
+          >
+            <View style={styles.pillContent}>
+              <Icon source={iconName} size={14} color={colors.onSurfaceVariant} />
+              <Text
+                variant="bodySmall"
+                style={[styles.deviceName, { color: colors.onSurface }]}
+                numberOfLines={1}
+                ellipsizeMode="tail"
+              >
+                {selectedDevice?.name ?? '—'}
+              </Text>
+              <Icon source="chevron-down" size={14} color={colors.onSurfaceVariant} />
+            </View>
+          </TouchableRipple>
+        }
+      >
+        {devices.map((device) => (
+          <Menu.Item
+            key={device.uid}
+            title={device.name}
+            onPress={() => {
+              onSelect(device.uid)
+              setMenuVisible(false)
+            }}
+            leadingIcon={
+              device.uid === (selectedUID ?? devices[0]?.uid) ? 'check' : undefined
+            }
+          />
+        ))}
+      </Menu>
+    </View>
   )
 }
 
 const styles = StyleSheet.create({
-  pill: {
+  wrapper: {
     flex: 1,
+  },
+  pill: {
     borderWidth: 1.5,
     borderRadius: 100,
     paddingHorizontal: 12,

--- a/src/hooks/useAudioDeviceRoute.ts
+++ b/src/hooks/useAudioDeviceRoute.ts
@@ -4,9 +4,16 @@ import * as AudioRoute from '../../modules/audio-route'
 import type { AudioPort } from '../../modules/audio-route'
 import { useAudioDeviceStore } from '../stores/audioDeviceStore'
 
+// モジュールレベルキャッシュ: 設定画面を開いた際に即座に表示するため
+// アプリ起動中はメモリに保持し、2回目以降の画面表示でラグをなくす
+let _deviceCache: { inputs: AudioPort[]; outputs: AudioPort[] } = {
+  inputs: [],
+  outputs: [],
+}
+
 export const useAudioDeviceRoute = () => {
-  const [availableInputs, setAvailableInputs] = useState<AudioPort[]>([])
-  const [availableOutputs, setAvailableOutputs] = useState<AudioPort[]>([])
+  const [availableInputs, setAvailableInputs] = useState<AudioPort[]>(_deviceCache.inputs)
+  const [availableOutputs, setAvailableOutputs] = useState<AudioPort[]>(_deviceCache.outputs)
 
   const preferredInputUID = useAudioDeviceStore((state) => state.preferredInputUID)
   const preferredOutputUID = useAudioDeviceStore((state) => state.preferredOutputUID)
@@ -20,6 +27,7 @@ export const useAudioDeviceRoute = () => {
         AudioRoute.getAvailableInputs(),
         AudioRoute.getAvailableOutputs(),
       ])
+      _deviceCache = { inputs, outputs }
       setAvailableInputs(inputs)
       setAvailableOutputs(outputs)
     } catch (error) {

--- a/src/hooks/useVoiceRecognition.ts
+++ b/src/hooks/useVoiceRecognition.ts
@@ -30,8 +30,6 @@ const IOS_AUDIO_SESSION_OPTIONS = {
   mode: 'default' as const,
 }
 
-type PendingTransition = 'command' | null
-
 export const useVoiceRecognition = (
   onCommandRecognized: (command: VoiceCommand) => void
 ): UseVoiceRecognitionResult => {
@@ -56,7 +54,6 @@ export const useVoiceRecognition = (
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const isListeningRef = useRef(false)
   const recognitionStateRef = useRef(recognitionState)
-  const pendingTransitionRef = useRef<PendingTransition>(null)
   const isOnlineRef = useRef(isOnline)
 
   // isOnlineRef を最新値に同期
@@ -65,9 +62,6 @@ export const useVoiceRecognition = (
   }, [isOnline])
 
   // 状態を ref と store の両方に同期的に更新する
-  // useEffect 経由の ref 更新はレンダリング後まで遅延し、
-  // end イベントが古い state を参照するレースコンディションの原因になるため、
-  // 全ての状態変更はこのヘルパーを通す
   const updateState = useCallback(
     (state: VoiceRecognitionState) => {
       recognitionStateRef.current = state
@@ -128,10 +122,27 @@ export const useVoiceRecognition = (
     }
   }, [])
 
+  // 単一の continuous セッションを開始する
+  // wakeword → command の遷移で stop/start を繰り返さないことで
+  // 音楽の途切れを防止する
+  const startRecognition = useCallback(() => {
+    try {
+      ExpoSpeechRecognitionModule.start({
+        lang: 'ja-JP',
+        interimResults: true,
+        continuous: true,
+        requiresOnDeviceRecognition: !isOnlineRef.current,
+        contextualStrings: [wakeWord, ...Object.values(commands)],
+        iosCategory: IOS_AUDIO_SESSION_OPTIONS,
+      })
+    } catch (error) {
+      console.error('[useVoiceRecognition] startRecognition failed:', error)
+    }
+  }, [wakeWord, commands])
+
   // 音声認識を停止
   const stopListening = useCallback(() => {
     clearCommandTimeout()
-    pendingTransitionRef.current = null
     isListeningRef.current = false
     try {
       ExpoSpeechRecognitionModule.stop()
@@ -142,58 +153,12 @@ export const useVoiceRecognition = (
     setLastRecognizedText(null)
   }, [clearCommandTimeout, updateState, setLastRecognizedText])
 
-  // 音声認識を実行する
-  const startRecognition = useCallback(
-    (continuous: boolean) => {
-      try {
-        const startOptions = {
-          lang: 'ja-JP',
-          interimResults: true,
-          continuous,
-          requiresOnDeviceRecognition: !isOnlineRef.current,
-          contextualStrings: [wakeWord, ...Object.values(commands)],
-          // iOS の音声セッション設定を明示的に指定
-          // デフォルトの allowBluetooth（HFP）と measurement モードを上書きし、
-          // A2DP 高音質を維持しつつ再生音量の低下を防ぐ
-          iosCategory: IOS_AUDIO_SESSION_OPTIONS,
-        }
-        ExpoSpeechRecognitionModule.start(startOptions)
-      } catch (error) {
-        console.error('[useVoiceRecognition] startRecognition failed:', error)
-      }
-    },
-    [wakeWord, commands]
-  )
-
-  // ウェイクワード検出用の認識を開始する
-  const startWakeWordRecognition = useCallback(() => {
-    updateState(VoiceRecognitionState.LISTENING_FOR_WAKEWORD)
-    startRecognition(true)
-  }, [updateState, startRecognition])
-
-  // コマンド認識を開始する（end イベントから呼ばれる）
-  const startCommandRecognition = useCallback(() => {
-    updateState(VoiceRecognitionState.LISTENING_FOR_COMMAND)
-    clearCommandTimeout()
-
-    // タイムアウト設定
-    timeoutRef.current = setTimeout(() => {
-      updateState(VoiceRecognitionState.IDLE)
-      setLastRecognizedText(null)
-      // ウェイクワード検出に戻る
-      if (isListeningRef.current) {
-        startWakeWordRecognition()
-      }
-    }, timeoutSeconds * 1000)
-
-    startRecognition(false)
-  }, [timeoutSeconds, clearCommandTimeout, updateState, setLastRecognizedText, startWakeWordRecognition, startRecognition])
-
   // ウェイクワード監視を開始（外部API）
   const startWakeWordListening = useCallback(() => {
     isListeningRef.current = true
-    startWakeWordRecognition()
-  }, [startWakeWordRecognition])
+    updateState(VoiceRecognitionState.LISTENING_FOR_WAKEWORD)
+    startRecognition()
+  }, [updateState, startRecognition])
 
   // 音声認識イベントリスナー
   useEffect(() => {
@@ -209,25 +174,38 @@ export const useVoiceRecognition = (
           recognitionStateRef.current === VoiceRecognitionState.LISTENING_FOR_WAKEWORD
         ) {
           if (containsWakeWord(transcript)) {
-            // ウェイクワード検出 → 認識を停止し、end イベントでコマンド認識に遷移
-            // stop() の前に遷移予約することで、end イベントが正しくコマンド認識を開始する
-            pendingTransitionRef.current = 'command'
-            ExpoSpeechRecognitionModule.stop()
+            // ウェイクワード検出 → セッションを止めずに状態だけ変更
+            // stop/start しないことで音楽の途切れを防止する
+            updateState(VoiceRecognitionState.LISTENING_FOR_COMMAND)
+
+            // コマンドタイムアウトを設定
+            clearCommandTimeout()
+            timeoutRef.current = setTimeout(() => {
+              if (
+                isListeningRef.current &&
+                recognitionStateRef.current ===
+                  VoiceRecognitionState.LISTENING_FOR_COMMAND
+              ) {
+                updateState(VoiceRecognitionState.LISTENING_FOR_WAKEWORD)
+                setLastRecognizedText(null)
+              }
+            }, timeoutSeconds * 1000)
           }
         } else if (
           recognitionStateRef.current === VoiceRecognitionState.LISTENING_FOR_COMMAND
         ) {
           const command = matchCommand(transcript)
-          if (command && event.isFinal) {
+          if (command) {
+            // コマンド検出 → 中間結果でも即座に実行（isFinal 待ち不要）
             clearCommandTimeout()
-            ExpoSpeechRecognitionModule.stop()
             updateState(VoiceRecognitionState.PROCESSING)
             onCommandRecognized(command)
 
-            // コマンド実行後、ウェイクワード検出に戻る
+            // フィードバック音の後にウェイクワード待機に戻る
             setTimeout(() => {
               if (isListeningRef.current) {
-                startWakeWordRecognition()
+                updateState(VoiceRecognitionState.LISTENING_FOR_WAKEWORD)
+                setLastRecognizedText(null)
               }
             }, 500)
           }
@@ -240,7 +218,6 @@ export const useVoiceRecognition = (
       (event) => {
         if (event.error === 'no-speech' || event.error === 'speech-timeout') {
           // no-speech / speech-timeout はウェイクワード待機中の正常な挙動
-          // end イベントが後に発火するのでここではリトライしない（二重起動防止）
           console.warn('[useVoiceRecognition] expected timeout:', event.error)
         } else {
           console.error('[useVoiceRecognition] recognition error:', event.error)
@@ -251,28 +228,19 @@ export const useVoiceRecognition = (
     const endSubscription = ExpoSpeechRecognitionModule.addListener(
       'end',
       () => {
-        // 全ての認識再開はここで一元管理する（二重起動を防止）
-        const transition = pendingTransitionRef.current
-        pendingTransitionRef.current = null
+        if (!isListeningRef.current) return
 
-        if (transition === 'command') {
-          // ウェイクワード検出後 → コマンド認識を開始
-          // stop() の完了を待ってから start() するので iOS の認識セッション競合を回避
-          startCommandRecognition()
-          return
-        }
-
-        // ウェイクワード待機中の自動再開（タイムアウト後など）
-        if (
-          isListeningRef.current &&
-          recognitionStateRef.current === VoiceRecognitionState.LISTENING_FOR_WAKEWORD
-        ) {
-          setTimeout(() => {
-            if (isListeningRef.current) {
-              startWakeWordRecognition()
-            }
-          }, 300)
-        }
+        // セッションが自然終了（iOS 制限 / タイムアウト）→ 再開
+        // PROCESSING 中（コマンド実行直後の 500ms）は再開しない
+        setTimeout(() => {
+          if (
+            isListeningRef.current &&
+            recognitionStateRef.current !== VoiceRecognitionState.PROCESSING
+          ) {
+            updateState(VoiceRecognitionState.LISTENING_FOR_WAKEWORD)
+            startRecognition()
+          }
+        }, 300)
       }
     )
 
@@ -284,19 +252,18 @@ export const useVoiceRecognition = (
   }, [ // eslint-disable-line react-hooks/exhaustive-deps
     containsWakeWord,
     matchCommand,
-    startCommandRecognition,
-    startWakeWordRecognition,
     clearCommandTimeout,
     updateState,
     setLastRecognizedText,
     onCommandRecognized,
+    startRecognition,
+    timeoutSeconds,
   ])
 
   // クリーンアップ
   useEffect(() => {
     return () => {
       clearCommandTimeout()
-      pendingTransitionRef.current = null
       isListeningRef.current = false
       try {
         ExpoSpeechRecognitionModule.stop()


### PR DESCRIPTION
## Summary

### デバイスピッカー表示速度
- モジュールレベルキャッシュを導入。設定画面を開いた際、初回はネイティブ取得、2回目以降はキャッシュから即座に表示し、バックグラウンドで最新化

### デバイスピッカー幅
- `AudioDevicePicker` を `View(flex: 1)` で包む。react-native-paperの`Menu`が内部でanchorを固定サイズのViewで包むため、pillの`flex: 1`が無効になっていた問題を修正

### コマンド応答遅延
- `event.isFinal`の待機を廃止し、中間結果（interimResults）でコマンドを即時検出・実行するように変更

### 音声認識時の音楽途切れ
- **根本原因**: wakeword検出→コマンド検出のたびに`stop()`→`start()`でオーディオセッションを再起動していたことで音楽が切れていた
- **修正**: `continuous: true`の単一セッションに統一。wakeword/command検出は内部状態の切り替えのみで行い、セッションの再起動はiOSのタイムアウト・エラー時のみに限定

## Architecture変更
```
Before: start(wakeword) → stop → start(command) → stop → start(wakeword) → ...
                          ↑ 音楽途切れ発生点

After:  start(continuous) ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━→
                          state変更のみ（stop/startなし → 途切れなし）
```

## Test plan

- [ ] 設定画面を2回開いて、2回目は即座にデバイスが表示される
- [ ] 2つのピッカーが画面幅いっぱいに並んで表示される
- [ ] ウェイクワード発話後、コマンドが即座に認識・実行される（isFinal待ちラグなし）
- [ ] 音楽再生中に音声認識をONにしても音楽が途切れない
- [ ] コマンド実行後、ウェイクワード待機に戻る

🤖 Generated with [Claude Code](https://claude.com/claude-code)