### PR TITLE
[Fix] コマンド認識失敗・設定画面音楽停止・Bluetoothマイク未適用を修正

### DIFF
--- a/modules/audio-route/ios/AudioRouteModule.swift
+++ b/modules/audio-route/ios/AudioRouteModule.swift
@@ -6,32 +6,36 @@ public class AudioRouteModule: Module {
     Name("AudioRoute")
 
     // 接続済み入力デバイス（マイク）一覧を返す
-    // Bluetoothデバイスを列挙するために一時的に .allowBluetooth を付与してから元に戻す
+    // setCategory は呼ばない（音楽再生を中断させないため）
+    // A2DP 接続中の Bluetooth デバイスは currentRoute.outputs から補完する
     AsyncFunction("getAvailableInputs") { () -> [[String: String]] in
       let session = AVAudioSession.sharedInstance()
-      let originalOptions = session.categoryOptions
+      var result: [[String: String]] = []
 
-      // .allowBluetooth がない場合は一時付与（BluetoothマイクがavailableInputsに出ない対策）
-      if !originalOptions.contains(.allowBluetooth) {
-        try? session.setCategory(session.category, mode: session.mode,
-                                  options: originalOptions.union(.allowBluetooth))
+      if let inputs = session.availableInputs {
+        result = inputs.map { port in
+          [
+            "uid": port.uid,
+            "name": port.portName,
+            "type": port.portType.rawValue,
+          ]
+        }
       }
 
-      let inputs = session.availableInputs ?? []
-
-      // 元のオプションに戻す
-      if !originalOptions.contains(.allowBluetooth) {
-        try? session.setCategory(session.category, mode: session.mode,
-                                  options: originalOptions)
+      // A2DP 接続中の Bluetooth デバイスが availableInputs に出ない場合でも
+      // マイク候補として追加する（allowBluetooth 未設定時の補完）
+      let btOutputTypes: [AVAudioSession.Port] = [.bluetoothA2DP, .bluetoothLE]
+      for port in session.currentRoute.outputs where btOutputTypes.contains(port.portType) {
+        if !result.contains(where: { $0["uid"] == port.uid }) {
+          result.append([
+            "uid": port.uid,
+            "name": port.portName,
+            "type": AVAudioSession.Port.bluetoothHFP.rawValue,
+          ])
+        }
       }
 
-      return inputs.map { port in
-        [
-          "uid": port.uid,
-          "name": port.portName,
-          "type": port.portType.rawValue,
-        ]
-      }
+      return result
     }
 
     // 利用可能な出力デバイス一覧を返す
@@ -62,6 +66,7 @@ public class AudioRouteModule: Module {
     }
 
     // 優先する入力デバイス（マイク）を設定する。nil で自動に戻す。
+    // Bluetooth マイクの場合、availableInputs に出るよう allowBluetooth を付与する
     AsyncFunction("setPreferredInput") { (uid: String?) throws in
       let session = AVAudioSession.sharedInstance()
 
@@ -70,14 +75,39 @@ public class AudioRouteModule: Module {
         return
       }
 
-      guard let inputs = session.availableInputs,
-            let port = inputs.first(where: { $0.uid == uid }) else {
-        // 指定ポートが見つからない場合は自動に戻す（エラーにしない）
-        try session.setPreferredInput(nil)
+      // 通常の入力から探す
+      if let inputs = session.availableInputs,
+         let port = inputs.first(where: { $0.uid == uid }) {
+        try session.setPreferredInput(port)
         return
       }
 
-      try session.setPreferredInput(port)
+      // 見つからない場合は Bluetooth デバイスの可能性
+      // allowBluetooth を付与して再探索する
+      let originalOptions = session.categoryOptions
+      if !originalOptions.contains(.allowBluetooth) {
+        try? session.setCategory(
+          session.category,
+          mode: session.mode,
+          options: originalOptions.union(.allowBluetooth)
+        )
+      }
+
+      if let inputs = session.availableInputs,
+         let port = inputs.first(where: { $0.uid == uid }) {
+        // allowBluetooth は維持する（HFP マイクに必要）
+        try session.setPreferredInput(port)
+      } else {
+        // それでも見つからない場合は元のオプションに戻して自動入力
+        if !originalOptions.contains(.allowBluetooth) {
+          try? session.setCategory(
+            session.category,
+            mode: session.mode,
+            options: originalOptions
+          )
+        }
+        try session.setPreferredInput(nil)
+      }
     }
 
     // 優先する出力デバイスを設定する。

--- a/src/hooks/useVoiceRecognition.ts
+++ b/src/hooks/useVoiceRecognition.ts
@@ -4,6 +4,8 @@ import NetInfo from '@react-native-community/netinfo'
 import { VoiceCommand, VoiceRecognitionState } from '../types'
 import { useVoiceStore } from '../stores/voiceStore'
 import { useSettingsStore } from '../stores/settingsStore'
+import { useAudioDeviceStore } from '../stores/audioDeviceStore'
+import * as AudioRoute from '../../modules/audio-route'
 
 interface UseVoiceRecognitionResult {
   recognitionState: VoiceRecognitionState
@@ -16,17 +18,19 @@ interface UseVoiceRecognitionResult {
 }
 
 // expo-speech-recognition の iOS 音声セッション設定
-// allowBluetoothA2DP: Bluetooth を A2DP（高音質）のまま維持し HFP 切り替えを防止
-// defaultToSpeaker: Bluetooth 未接続時はスピーカーを使用
-// mixWithOthers: TrackPlayer の再生を中断しない
-// mode: 'default'（measurement モードは再生音量を下げるため使わない）
+// allowBluetooth:     Bluetooth マイクを使用可能にする（HFP）
+// allowBluetoothA2DP: Bluetooth マイク未使用時は A2DP 高音質を維持
+// defaultToSpeaker:   Bluetooth 未接続時はスピーカーを使用
+// mixWithOthers:      TrackPlayer の再生を中断しない
+// mode: 'default'     measurement モードは再生音量を下げるため使わない
 const IOS_AUDIO_SESSION_OPTIONS = {
   category: 'playAndRecord' as const,
   categoryOptions: [
+    'allowBluetooth',
     'allowBluetoothA2DP',
     'defaultToSpeaker',
     'mixWithOthers',
-  ] as ('allowBluetoothA2DP' | 'defaultToSpeaker' | 'mixWithOthers')[],
+  ] as ('allowBluetooth' | 'allowBluetoothA2DP' | 'defaultToSpeaker' | 'mixWithOthers')[],
   mode: 'default' as const,
 }
 
@@ -53,15 +57,14 @@ export const useVoiceRecognition = (
   const hasPermissionRef = useRef<boolean | null>(null)
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const isListeningRef = useRef(false)
+  const isSessionActiveRef = useRef(false)
   const recognitionStateRef = useRef(recognitionState)
   const isOnlineRef = useRef(isOnline)
 
-  // isOnlineRef を最新値に同期
   useEffect(() => {
     isOnlineRef.current = isOnline
   }, [isOnline])
 
-  // 状態を ref と store の両方に同期的に更新する
   const updateState = useCallback(
     (state: VoiceRecognitionState) => {
       recognitionStateRef.current = state
@@ -70,7 +73,6 @@ export const useVoiceRecognition = (
     [setRecognitionState]
   )
 
-  // ネットワーク状態の監視
   useEffect(() => {
     const unsubscribe = NetInfo.addEventListener((state) => {
       setIsOnline(state.isConnected ?? false)
@@ -78,7 +80,6 @@ export const useVoiceRecognition = (
     return () => unsubscribe()
   }, [setIsOnline])
 
-  // 権限チェック
   const requestPermission = useCallback(async (): Promise<boolean> => {
     try {
       const result =
@@ -92,7 +93,6 @@ export const useVoiceRecognition = (
     }
   }, [])
 
-  // 認識テキストからコマンドを解析
   const matchCommand = useCallback(
     (text: string): VoiceCommand | null => {
       const normalizedText = text.trim().toLowerCase()
@@ -106,7 +106,6 @@ export const useVoiceRecognition = (
     [commands]
   )
 
-  // ウェイクワード検出チェック
   const containsWakeWord = useCallback(
     (text: string): boolean => {
       return text.trim().toLowerCase().includes(wakeWord.toLowerCase())
@@ -114,7 +113,6 @@ export const useVoiceRecognition = (
     [wakeWord]
   )
 
-  // タイムアウトをクリア
   const clearCommandTimeout = useCallback(() => {
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current)
@@ -123,8 +121,7 @@ export const useVoiceRecognition = (
   }, [])
 
   // 単一の continuous セッションを開始する
-  // wakeword → command の遷移で stop/start を繰り返さないことで
-  // 音楽の途切れを防止する
+  // wakeword → command の遷移で stop/start を繰り返さないことで音楽の途切れを防止する
   const startRecognition = useCallback(() => {
     try {
       ExpoSpeechRecognitionModule.start({
@@ -140,7 +137,6 @@ export const useVoiceRecognition = (
     }
   }, [wakeWord, commands])
 
-  // 音声認識を停止
   const stopListening = useCallback(() => {
     clearCommandTimeout()
     isListeningRef.current = false
@@ -153,15 +149,28 @@ export const useVoiceRecognition = (
     setLastRecognizedText(null)
   }, [clearCommandTimeout, updateState, setLastRecognizedText])
 
-  // ウェイクワード監視を開始（外部API）
   const startWakeWordListening = useCallback(() => {
     isListeningRef.current = true
     updateState(VoiceRecognitionState.LISTENING_FOR_WAKEWORD)
     startRecognition()
   }, [updateState, startRecognition])
 
-  // 音声認識イベントリスナー
   useEffect(() => {
+    // セッション開始イベント:
+    // expo-speech-recognition が setCategory + setActive を完了したタイミングで
+    // preferredInput を適用する。この時点では allowBluetooth が有効になっているため
+    // Bluetooth マイクが availableInputs に現れ、setPreferredInput が成功する
+    const startSubscription = ExpoSpeechRecognitionModule.addListener(
+      'start',
+      () => {
+        isSessionActiveRef.current = true
+        const { preferredInputUID } = useAudioDeviceStore.getState()
+        AudioRoute.setPreferredInput(preferredInputUID).catch((err) => {
+          console.error('[useVoiceRecognition] setPreferredInput failed:', err)
+        })
+      }
+    )
+
     const resultSubscription = ExpoSpeechRecognitionModule.addListener(
       'result',
       (event) => {
@@ -178,7 +187,6 @@ export const useVoiceRecognition = (
             // stop/start しないことで音楽の途切れを防止する
             updateState(VoiceRecognitionState.LISTENING_FOR_COMMAND)
 
-            // コマンドタイムアウトを設定
             clearCommandTimeout()
             timeoutRef.current = setTimeout(() => {
               if (
@@ -202,10 +210,14 @@ export const useVoiceRecognition = (
             onCommandRecognized(command)
 
             // フィードバック音の後にウェイクワード待機に戻る
+            // セッションが PROCESSING 中に終了していた場合は再開する
             setTimeout(() => {
               if (isListeningRef.current) {
                 updateState(VoiceRecognitionState.LISTENING_FOR_WAKEWORD)
                 setLastRecognizedText(null)
+                if (!isSessionActiveRef.current) {
+                  startRecognition()
+                }
               }
             }, 500)
           }
@@ -228,16 +240,19 @@ export const useVoiceRecognition = (
     const endSubscription = ExpoSpeechRecognitionModule.addListener(
       'end',
       () => {
+        isSessionActiveRef.current = false
+
         if (!isListeningRef.current) return
 
         // セッションが自然終了（iOS 制限 / タイムアウト）→ 再開
-        // PROCESSING 中（コマンド実行直後の 500ms）は再開しない
+        // 状態はリセットしない: LISTENING_FOR_COMMAND 中に end が来ても
+        // コマンド待機を継続するため、現在の状態のままセッションを再起動する
+        // PROCESSING 中（コマンド実行直後の 500ms）は 500ms コールバックが再開を担う
         setTimeout(() => {
           if (
             isListeningRef.current &&
             recognitionStateRef.current !== VoiceRecognitionState.PROCESSING
           ) {
-            updateState(VoiceRecognitionState.LISTENING_FOR_WAKEWORD)
             startRecognition()
           }
         }, 300)
@@ -245,6 +260,7 @@ export const useVoiceRecognition = (
     )
 
     return () => {
+      startSubscription.remove()
       resultSubscription.remove()
       errorSubscription.remove()
       endSubscription.remove()
@@ -260,7 +276,6 @@ export const useVoiceRecognition = (
     timeoutSeconds,
   ])
 
-  // クリーンアップ
   useEffect(() => {
     return () => {
       clearCommandTimeout()


### PR DESCRIPTION
## 修正した問題と根本原因

### 1. 再生以外のコマンドが認識されない
**根本原因**: `end` イベントハンドラが `LISTENING_FOR_COMMAND` 状態を `LISTENING_FOR_WAKEWORD` にリセットしていた。ウェイクワードとコマンドの発話間の無音でセッションが一時終了 → `end` 発火 → 状態リセット → コマンドを聞き逃す

**修正**: `end` ハンドラは状態を変更せず、現在の状態のままセッションを再起動するように変更

### 2. 設定画面を開く時に音楽が一瞬止まる
**根本原因**: `getAvailableInputs()` 内で `setCategory(.allowBluetooth)` を毎回呼んでいたため、設定画面を開くたびにオーディオセッションが再設定され音楽が中断されていた

**修正**: `setCategory` を廃止。代わりに `currentRoute.outputs` の Bluetooth デバイスを入力候補として補完する方式に変更（セッション変更なし）

### 3. 選択したイヤホンではなく内蔵マイクが使われる
**根本原因 A**: `IOS_AUDIO_SESSION_OPTIONS` に `allowBluetooth` がなく、Bluetooth デバイスが `availableInputs` に現れないため `setPreferredInput` が無効化されていた

**根本原因 B**: `applyPreferences` は SettingsScreen のマウント時のみ呼ばれており、MainScreen で音声認識が起動する際には preferredInput が適用されていなかった

**修正**:
- `IOS_AUDIO_SESSION_OPTIONS` に `allowBluetooth` を追加
- `start` イベントリスナーを追加: セッション開始後（`setCategory + setActive` 完了後）に `preferredInputUID` を適用。この時点で `allowBluetooth` が有効なため Bluetooth マイクが `availableInputs` に現れ、`setPreferredInput` が成功する

## Test plan

- [ ] ウェイクワード後に一拍置いてから「停止」「次」「前」などを言い、正しく実行される
- [ ] 設定画面を開いても音楽が止まらない
- [ ] イヤホンをマイクに設定した状態で音声認識が内蔵マイクではなくイヤホンで拾われる
- [ ] PROCESSING 後に正常にウェイクワード待機に戻る

> **注意**: Swift 変更を含むため `npx expo prebuild --clean && cd ios && pod install && cd ..` → Xcode ビルドが必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)