### PR TITLE
[Fix] コマンド認識のresultsインデックス・設定画面音質低下・マイクルーティング

### DIFF
--- a/modules/audio-route/ios/AudioRouteModule.swift
+++ b/modules/audio-route/ios/AudioRouteModule.swift
@@ -6,6 +6,7 @@ public class AudioRouteModule: Module {
     Name("AudioRoute")
 
     // 接続済み入力デバイス（マイク）一覧を返す
+    // 開発用: 内蔵マイクは除外し外部デバイスのみ返す
     // setCategory は呼ばない（音楽再生を中断させないため）
     // A2DP 接続中の Bluetooth デバイスは currentRoute.outputs から補完する
     AsyncFunction("getAvailableInputs") { () -> [[String: String]] in
@@ -13,13 +14,16 @@ public class AudioRouteModule: Module {
       var result: [[String: String]] = []
 
       if let inputs = session.availableInputs {
-        result = inputs.map { port in
-          [
-            "uid": port.uid,
-            "name": port.portName,
-            "type": port.portType.rawValue,
-          ]
-        }
+        // 開発用: 内蔵マイク (builtInMicrophone) を除外
+        result = inputs
+          .filter { $0.portType != .builtInMicrophone }
+          .map { port in
+            [
+              "uid": port.uid,
+              "name": port.portName,
+              "type": port.portType.rawValue,
+            ]
+          }
       }
 
       // A2DP 接続中の Bluetooth デバイスが availableInputs に出ない場合でも
@@ -43,7 +47,6 @@ public class AudioRouteModule: Module {
     AsyncFunction("getAvailableOutputs") { () -> [[String: String]] in
       var outputs: [[String: String]] = []
 
-      // 現在のルートの出力ポートを追加（接続中の外部デバイス）
       let currentOutputs = AVAudioSession.sharedInstance().currentRoute.outputs
       for port in currentOutputs {
         if port.portType != .builtInSpeaker {
@@ -55,7 +58,6 @@ public class AudioRouteModule: Module {
         }
       }
 
-      // 内蔵スピーカーは常に選択肢として末尾に追加
       outputs.append([
         "uid": "builtin_speaker",
         "name": "内蔵スピーカー",
@@ -66,7 +68,8 @@ public class AudioRouteModule: Module {
     }
 
     // 優先する入力デバイス（マイク）を設定する。nil で自動に戻す。
-    // Bluetooth マイクの場合、availableInputs に出るよう allowBluetooth を付与する
+    // セッション変更は行わない: Bluetooth デバイスが availableInputs に含まれない場合は
+    // 何もしない（音声認識の start イベントで allowBluetooth が有効な状態で再試行される）
     AsyncFunction("setPreferredInput") { (uid: String?) throws in
       let session = AVAudioSession.sharedInstance()
 
@@ -75,39 +78,14 @@ public class AudioRouteModule: Module {
         return
       }
 
-      // 通常の入力から探す
-      if let inputs = session.availableInputs,
-         let port = inputs.first(where: { $0.uid == uid }) {
-        try session.setPreferredInput(port)
+      guard let inputs = session.availableInputs,
+            let port = inputs.first(where: { $0.uid == uid }) else {
+        // availableInputs に見つからない場合はセッション変更せず何もしない
+        // 音声認識開始時に allowBluetooth が有効になった後に再適用される
         return
       }
 
-      // 見つからない場合は Bluetooth デバイスの可能性
-      // allowBluetooth を付与して再探索する
-      let originalOptions = session.categoryOptions
-      if !originalOptions.contains(.allowBluetooth) {
-        try? session.setCategory(
-          session.category,
-          mode: session.mode,
-          options: originalOptions.union(.allowBluetooth)
-        )
-      }
-
-      if let inputs = session.availableInputs,
-         let port = inputs.first(where: { $0.uid == uid }) {
-        // allowBluetooth は維持する（HFP マイクに必要）
-        try session.setPreferredInput(port)
-      } else {
-        // それでも見つからない場合は元のオプションに戻して自動入力
-        if !originalOptions.contains(.allowBluetooth) {
-          try? session.setCategory(
-            session.category,
-            mode: session.mode,
-            options: originalOptions
-          )
-        }
-        try session.setPreferredInput(nil)
-      }
+      try session.setPreferredInput(port)
     }
 
     // 優先する出力デバイスを設定する。

--- a/src/hooks/useAudioDeviceRoute.ts
+++ b/src/hooks/useAudioDeviceRoute.ts
@@ -46,9 +46,12 @@ export const useAudioDeviceRoute = () => {
     }
   }, [preferredInputUID, preferredOutputUID])
 
+  // マウント時はデバイス一覧の取得のみ行う
+  // applyPreferences はユーザーがデバイスを変更したとき
+  // または音声認識の start イベントで適用される
+  // 設定画面を開くだけで setCategory が走り音楽が途切れるのを防ぐ
   useEffect(() => {
     refreshDevices()
-    applyPreferences()
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   // フォアグラウンド復帰時にデバイス一覧を再スキャン

--- a/src/hooks/useVoiceRecognition.ts
+++ b/src/hooks/useVoiceRecognition.ts
@@ -120,8 +120,6 @@ export const useVoiceRecognition = (
     }
   }, [])
 
-  // 単一の continuous セッションを開始する
-  // wakeword → command の遷移で stop/start を繰り返さないことで音楽の途切れを防止する
   const startRecognition = useCallback(() => {
     try {
       ExpoSpeechRecognitionModule.start({
@@ -158,23 +156,39 @@ export const useVoiceRecognition = (
   useEffect(() => {
     // セッション開始イベント:
     // expo-speech-recognition が setCategory + setActive を完了したタイミングで
-    // preferredInput を適用する。この時点では allowBluetooth が有効になっているため
-    // Bluetooth マイクが availableInputs に現れ、setPreferredInput が成功する
+    // preferredInput を適用する。allowBluetooth が有効な状態で呼ぶため
+    // Bluetooth マイクが availableInputs に含まれ setPreferredInput が成功する
     const startSubscription = ExpoSpeechRecognitionModule.addListener(
       'start',
-      () => {
+      async () => {
         isSessionActiveRef.current = true
-        const { preferredInputUID } = useAudioDeviceStore.getState()
-        AudioRoute.setPreferredInput(preferredInputUID).catch((err) => {
+
+        try {
+          const { preferredInputUID } = useAudioDeviceStore.getState()
+          if (preferredInputUID) {
+            await AudioRoute.setPreferredInput(preferredInputUID)
+          } else {
+            // 明示的に選択されていない場合は最初の利用可能デバイスを自動選択
+            // （開発用: 内蔵マイクはフィルタ済みなので外部デバイスが優先される）
+            const inputs = await AudioRoute.getAvailableInputs()
+            if (inputs.length > 0) {
+              await AudioRoute.setPreferredInput(inputs[0].uid)
+            }
+          }
+        } catch (err) {
           console.error('[useVoiceRecognition] setPreferredInput failed:', err)
-        })
+        }
       }
     )
 
     const resultSubscription = ExpoSpeechRecognitionModule.addListener(
       'result',
       (event) => {
-        const transcript = event.results[0]?.transcript ?? ''
+        // continuous モードでは results 配列にセグメントが蓄積される
+        // results[0] は最初のセグメント（ウェイクワード）のまま固定されるため、
+        // 最新のセグメント（末尾）を読む必要がある
+        const lastResult = event.results[event.results.length - 1]
+        const transcript = lastResult?.transcript ?? ''
         if (!transcript) return
 
         setLastRecognizedText(transcript)
@@ -183,8 +197,6 @@ export const useVoiceRecognition = (
           recognitionStateRef.current === VoiceRecognitionState.LISTENING_FOR_WAKEWORD
         ) {
           if (containsWakeWord(transcript)) {
-            // ウェイクワード検出 → セッションを止めずに状態だけ変更
-            // stop/start しないことで音楽の途切れを防止する
             updateState(VoiceRecognitionState.LISTENING_FOR_COMMAND)
 
             clearCommandTimeout()
@@ -204,13 +216,10 @@ export const useVoiceRecognition = (
         ) {
           const command = matchCommand(transcript)
           if (command) {
-            // コマンド検出 → 中間結果でも即座に実行（isFinal 待ち不要）
             clearCommandTimeout()
             updateState(VoiceRecognitionState.PROCESSING)
             onCommandRecognized(command)
 
-            // フィードバック音の後にウェイクワード待機に戻る
-            // セッションが PROCESSING 中に終了していた場合は再開する
             setTimeout(() => {
               if (isListeningRef.current) {
                 updateState(VoiceRecognitionState.LISTENING_FOR_WAKEWORD)
@@ -229,7 +238,6 @@ export const useVoiceRecognition = (
       'error',
       (event) => {
         if (event.error === 'no-speech' || event.error === 'speech-timeout') {
-          // no-speech / speech-timeout はウェイクワード待機中の正常な挙動
           console.warn('[useVoiceRecognition] expected timeout:', event.error)
         } else {
           console.error('[useVoiceRecognition] recognition error:', event.error)
@@ -244,10 +252,6 @@ export const useVoiceRecognition = (
 
         if (!isListeningRef.current) return
 
-        // セッションが自然終了（iOS 制限 / タイムアウト）→ 再開
-        // 状態はリセットしない: LISTENING_FOR_COMMAND 中に end が来ても
-        // コマンド待機を継続するため、現在の状態のままセッションを再起動する
-        // PROCESSING 中（コマンド実行直後の 500ms）は 500ms コールバックが再開を担う
         setTimeout(() => {
           if (
             isListeningRef.current &&

--- a/src/services/audioService.ts
+++ b/src/services/audioService.ts
@@ -31,6 +31,7 @@ export const audioService = {
         iosCategoryOptions: [
           IOSCategoryOptions.AllowBluetoothA2DP,
           IOSCategoryOptions.DefaultToSpeaker,
+          IOSCategoryOptions.MixWithOthers,
         ],
       })
       await TrackPlayer.updateOptions({


### PR DESCRIPTION
## 修正した問題と根本原因

### 1. 再生以外のコマンドが認識されない（最重要）

**根本原因**: `continuous: true` モードでは iOS の `SFSpeechRecognizer` が `results` 配列にセグメントを蓄積する。`results[0]` は常に**最初のセグメント（ウェイクワード）**を返し、新しい発話は `results[1]`, `results[2]` ... に追加される。

```
results[0] = "はい行きます"  ← 常にこれを読んでいた
results[1] = "停止"          ← コマンドはここにある（読まれなかった）
```

**修正**: `event.results[event.results.length - 1]` で最新セグメントを読むように変更

### 2. 設定画面を開くと音質が低下する

**根本原因**: `useAudioDeviceRoute` の `applyPreferences()` が設定画面マウント時に毎回実行 → `setPreferredInput()` (Swift) 内の `setCategory(.allowBluetooth)` がオーディオセッションを A2DP → HFP に切り替え → 音質低下。一時停止→再生で TrackPlayer が A2DP に戻すため音質が回復する。

**修正**:
- 設定画面マウント時は `refreshDevices()` のみ実行（`applyPreferences()` 削除）
- Swift の `setPreferredInput` から `setCategory(.allowBluetooth)` を完全除去（セッション変更なし）
- 入力設定は音声認識の `start` イベントで `allowBluetooth` が有効な状態で適用する

### 3. 内蔵マイクが使用される

**根本原因**: `preferredInputUID` が `null` の場合、iOS が自動で内蔵マイクを選択する。

**修正**:
- `start` イベントで `preferredInputUID` が `null` なら `getAvailableInputs()` の最初のデバイスを自動選択
- 開発用: `getAvailableInputs()` から内蔵マイク (`builtInMicrophone`) を除外

### 4. audioService

- TrackPlayer の `setupPlayer` に `MixWithOthers` を追加し、音声認識のオーディオセッションとの競合を防止

## Test plan

- [ ] ウェイクワード後に「停止」「次」「前」「最初から」等を言い、正しいコマンドが実行される
- [ ] 設定画面を開いても音楽の品質が落ちない
- [ ] 設定画面を開いても音楽が途切れない
- [ ] Bluetooth イヤホン接続時、内蔵マイクではなくイヤホンのマイクが使用される
- [ ] マイクピッカーに内蔵マイクが表示されない

> **注意**: Swift 変更を含むため `npx expo prebuild --clean && cd ios && pod install && cd ..` → Xcode ビルドが必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)