### PR TITLE
[Fix] AudioRouteModule の builtInMicrophone ビルドエラーを修正

### DIFF
--- a/modules/audio-route/ios/AudioRouteModule.swift
+++ b/modules/audio-route/ios/AudioRouteModule.swift
@@ -16,7 +16,7 @@ public class AudioRouteModule: Module {
       if let inputs = session.availableInputs {
         // 開発用: 内蔵マイク (builtInMicrophone) を除外
         result = inputs
-          .filter { $0.portType != .builtInMicrophone }
+          .filter { $0.portType != .builtInMic }
           .map { port in
             [
               "uid": port.uid,


### PR DESCRIPTION
## Summary
- `AVAudioSession.Port.builtInMicrophone` は存在しない API 名のためビルドエラーが発生していた
- 正しい `.builtInMic` に修正

## 変更ファイル
- `modules/audio-route/ios/AudioRouteModule.swift`（1行修正）

## Test plan
- [ ] Xcode でビルドエラーが解消されることを確認
- [ ] 外部マイクデバイス一覧から内蔵マイクが除外されることを確認

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)