### PR TITLE
[Fix] Bluetooth表示・コマンド処理・マイクルーティングを修正

### DIFF
--- a/docs/ios-audio-session-behavior.md
+++ b/docs/ios-audio-session-behavior.md
@@ -1,0 +1,167 @@
+# iOS AVAudioSession 実機挙動メモ
+
+このファイルは**実機テストで確認された事実**を蓄積する場所である。
+AI がオーディオ関連のバグを修正する際、推測ではなくこの文書の事実に基づいて判断すること。
+
+> 新しい事実が判明したら、必ずこのファイルに追記すること。
+
+---
+
+## 1. AVAudioSession.Port の rawValue
+
+| Swift の列挙子 | rawValue（実際の文字列） | 備考 |
+|---|---|---|
+| `.builtInMic` | `"MicrophoneBuiltIn"` | `.builtInMicrophone` は存在しない。#62 で修正 |
+| `.builtInSpeaker` | `"Speaker"` | |
+| `.bluetoothA2DP` | `"BluetoothA2DPOutput"` | 出力専用（高音質ステレオ） |
+| `.bluetoothHFP` | `"BluetoothHFP"` | 入出力両対応（低音質モノラル） |
+| `.bluetoothLE` | `"BluetoothLE"` | |
+
+**教訓**: Swift の `AVAudioSession.Port` 列挙子名と rawValue は異なる。コード内でフィルタする際は列挙子（`.builtInMic`）を使い、rawValue 文字列をハードコードしない。
+
+---
+
+## 2. Bluetooth プロファイル切り替え（A2DP ↔ HFP）
+
+### 確認済みの事実
+
+- Bluetooth イヤホン接続中、`setCategory(.playAndRecord)` を呼ぶと **A2DP → HFP に自動切り替え**が発生する
+- HFP は**モノラル・低ビットレート**のため、音楽の音質が著しく低下する
+- `setCategory` は `expo-speech-recognition` の `start()` 内部で呼ばれる
+- `setCategory` を**設定画面を開いただけで呼ぶと、音楽再生中に音質が低下する**（#59 で修正）
+
+### 対策（現在の実装）
+
+- 設定画面（`useAudioDeviceRoute`）では `setCategory` を呼ばない。デバイス一覧の取得のみ行う
+- `setCategory` は音声認識の `start` 時のみ実行される（`expo-speech-recognition` 内部で自動実行）
+- `iosCategory` オプションで `allowBluetooth` と `allowBluetoothA2DP` を両方指定し、iOS に最適なプロファイルを選ばせる
+
+---
+
+## 3. availableInputs と Bluetooth デバイス
+
+### 確認済みの事実
+
+- `AVAudioSession.sharedInstance().availableInputs` は**現在のカテゴリ設定で利用可能なデバイス**のみ返す
+- A2DP 接続中（`allowBluetooth` 未設定時）は、Bluetooth デバイスが `availableInputs` に**含まれない**
+- `setCategory(.playAndRecord, options: .allowBluetooth)` 後に初めて Bluetooth マイクが `availableInputs` に出現する
+- そのため `setPreferredInput` を音声認識の `start` イベント（= `setCategory` 完了後）で呼ぶ必要がある（#55, #59 で修正）
+
+### 対策（現在の実装）
+
+- `useVoiceRecognition` の `start` イベントリスナー内で `setPreferredInput` を適用
+- `AudioRouteModule.swift` の `setPreferredInput` は、`availableInputs` にデバイスが見つからない場合はサイレントに何もしない（エラーにしない）
+- `getAvailableInputs` では A2DP 出力中の Bluetooth デバイスを `currentRoute.outputs` から補完して返す
+
+---
+
+## 4. expo-audio / expo-av / react-native-track-player の共存
+
+### 確認済みの事実
+
+- `expo-av` の `Audio.setAudioModeAsync` は内部で `setCategory` を呼ぶため、Bluetooth プロファイル切り替えが発生する（#48 で expo-audio に移行した原因）
+- `expo-audio` の `setAudioModeAsync` も `setCategory` を呼ぶが、`allowsRecording: true` を設定することで TrackPlayer の `PlayAndRecord` カテゴリと競合しない（#48 で修正）
+- `soundService`（フィードバック音）で `allowsRecording: false` にすると、expo-audio が `Playback` カテゴリに戻してしまい、音声認識時に再度プロファイル切り替えが走る
+- `keepAudioSessionActive: true` を使うことで、フィードバック音再生後にセッションが非アクティブ化されず TrackPlayer が中断しない
+
+### ライブラリの役割分担（現在）
+
+| 用途 | ライブラリ | 理由 |
+|---|---|---|
+| 音楽再生 | `react-native-track-player` | バックグラウンド再生・ロック画面対応 |
+| フィードバック音 | `expo-audio` | 短い音の再生に適切。expo-av は Bluetooth 問題あり |
+| 音声認識 | `expo-speech-recognition` | iOS の SFSpeechRecognizer を利用 |
+
+---
+
+## 5. expo-speech-recognition の挙動
+
+### continuous モードの results 配列
+
+- `continuous: true` の場合、`event.results` 配列にセグメントが**蓄積**される
+- `results[0]` は最初のセグメント（ウェイクワード部分）のまま固定される
+- **最新の認識結果は `results[results.length - 1]`** を読む必要がある（#60 で修正）
+- `results[0]` を読むと、ウェイクワードの後にコマンドを言っても常にウェイクワードのテキストが返り、コマンドが認識されない
+
+### start イベント
+
+- `start` イベントは `expo-speech-recognition` が `setCategory` + `setActive` を完了した後に発火する
+- このタイミングで `setPreferredInput` を呼ぶと、`allowBluetooth` が有効な状態なので Bluetooth マイクが利用可能
+
+### no-speech / speech-timeout エラー
+
+- ユーザーが何も話さないと `no-speech` または `speech-timeout` エラーが発生する
+- これは正常な挙動なのでエラーログではなく `console.warn` で記録する（#46 で修正）
+- `end` イベント後に再起動すれば連続リスニングが継続する
+
+---
+
+## 6. AudioRouteModule（カスタムネイティブモジュール）
+
+### ビルド関連
+
+- Expo Modules として `modules/audio-route/` に配置
+- `requireOptionalNativeModule` を使い、prebuild 前（ネイティブモジュール未ビルド時）でもクラッシュしない（#55 で修正）
+- podspec ファイルが必要（#56 で追加）
+
+### 設計上の注意
+
+- `getAvailableInputs` / `getAvailableOutputs` は `setCategory` を呼ばない。呼ぶと音楽が途切れる
+- `setPreferredInput` も `setCategory` を呼ばない。`availableInputs` に無いデバイスはサイレントにスキップ
+- `setPreferredOutput` は `overrideOutputAudioPort` を使用（`.speaker` で内蔵スピーカー強制、`.none` で通常ルーティング）
+
+---
+
+## 7. Bluetooth デバイスの UID とプロファイル切り替え
+
+### 確認済みの事実
+
+- A2DP 出力専用デバイス（Bluetooth スピーカー）は `availableInputs` に含まれない（入力非対応）
+- A2DP モードの UID と HFP モードの UID は**同じデバイスでも異なる場合がある**
+- `setPreferredInput` は `availableInputs` の UID 完全一致で検索するため、プロファイル切替後に UID が変わるとサイレントに失敗する（#63 で修正）
+- `currentRoute.outputs` に A2DP デバイスが出現しても、そのデバイスが入力（マイク）に対応するとは限らない
+
+### 対策（現在の実装）
+
+- `getAvailableInputs` から A2DP フォールバックを削除（偽 HFP エントリの問題）
+- `setPreferredInput` に名前ベースのフォールバック検索を追加
+- `audioDeviceStore` にデバイス名を保存し、UID 不一致時に名前で再検索
+- TS 層で Bluetooth デバイスを入出力両方のピッカーに表示（ユーザーが自由に選択可能）
+
+---
+
+## 8. expo-speech-recognition continuous モードのトランスクリプト蓄積
+
+### 確認済みの事実
+
+- continuous モードでは `event.results` のトランスクリプトが蓄積される場合がある
+- 蓄積されたテキスト内に前回のコマンド（例: 「再生」）が残ると、`matchCommand` が `Object.entries` の順番で常に先頭のコマンドをマッチしてしまう（#63 で修正）
+- `Object.entries(commands)` は PLAY を最初に返すため、蓄積テキストに「再生」が含まれると他のコマンドが実行されない
+
+### 対策（現在の実装）
+
+- ウェイクワード検出時のトランスクリプトを記録（`wakeWordTranscriptRef`）
+- コマンドマッチング時はウェイクワード部分を除外し、新しいテキストのみで判定
+- セッション再開で結果がリセットされた場合も正常動作（`startsWith` チェック）
+
+---
+
+## 追記ルール
+
+新しい事実が判明した場合、以下の形式で追記すること:
+
+```markdown
+## N. セクションタイトル
+
+### 確認済みの事実
+
+- 事実1（#Issue番号 で確認）
+- 事実2
+
+### 対策（現在の実装）
+
+- 対策1
+- 対策2
+```
+
+**推測や未確認の情報は書かない。実機で確認された事実のみ記載する。**

--- a/modules/audio-route/index.ts
+++ b/modules/audio-route/index.ts
@@ -15,8 +15,12 @@ export const getAvailableInputs = (): Promise<AudioPort[]> =>
 export const getAvailableOutputs = (): Promise<AudioPort[]> =>
   AudioRouteNativeModule?.getAvailableOutputs() ?? Promise.resolve([])
 
-export const setPreferredInput = (uid: string | null): Promise<void> =>
-  AudioRouteNativeModule?.setPreferredInput(uid) ?? Promise.resolve()
+export const setPreferredInput = (
+  uid: string | null,
+  name?: string | null
+): Promise<void> =>
+  AudioRouteNativeModule?.setPreferredInput(uid, name ?? null) ??
+  Promise.resolve()
 
 export const setPreferredOutput = (uid: string): Promise<void> =>
   AudioRouteNativeModule?.setPreferredOutput(uid) ?? Promise.resolve()

--- a/modules/audio-route/ios/AudioRouteModule.swift
+++ b/modules/audio-route/ios/AudioRouteModule.swift
@@ -8,13 +8,14 @@ public class AudioRouteModule: Module {
     // 接続済み入力デバイス（マイク）一覧を返す
     // 開発用: 内蔵マイクは除外し外部デバイスのみ返す
     // setCategory は呼ばない（音楽再生を中断させないため）
-    // A2DP 接続中の Bluetooth デバイスは currentRoute.outputs から補完する
+    // A2DP 出力専用デバイスは入力リストに含めない（#63 で修正）
+    // Bluetooth デバイスは TS 層で両ピッカーに統合される
     AsyncFunction("getAvailableInputs") { () -> [[String: String]] in
       let session = AVAudioSession.sharedInstance()
       var result: [[String: String]] = []
 
       if let inputs = session.availableInputs {
-        // 開発用: 内蔵マイク (builtInMicrophone) を除外
+        // 開発用: 内蔵マイクを除外
         result = inputs
           .filter { $0.portType != .builtInMic }
           .map { port in
@@ -24,19 +25,6 @@ public class AudioRouteModule: Module {
               "type": port.portType.rawValue,
             ]
           }
-      }
-
-      // A2DP 接続中の Bluetooth デバイスが availableInputs に出ない場合でも
-      // マイク候補として追加する（allowBluetooth 未設定時の補完）
-      let btOutputTypes: [AVAudioSession.Port] = [.bluetoothA2DP, .bluetoothLE]
-      for port in session.currentRoute.outputs where btOutputTypes.contains(port.portType) {
-        if !result.contains(where: { $0["uid"] == port.uid }) {
-          result.append([
-            "uid": port.uid,
-            "name": port.portName,
-            "type": AVAudioSession.Port.bluetoothHFP.rawValue,
-          ])
-        }
       }
 
       return result
@@ -70,7 +58,9 @@ public class AudioRouteModule: Module {
     // 優先する入力デバイス（マイク）を設定する。nil で自動に戻す。
     // セッション変更は行わない: Bluetooth デバイスが availableInputs に含まれない場合は
     // 何もしない（音声認識の start イベントで allowBluetooth が有効な状態で再試行される）
-    AsyncFunction("setPreferredInput") { (uid: String?) throws in
+    // uid と name の両方を受け取り、UID 不一致時は名前でフォールバック検索する（#63）
+    // Bluetooth プロファイル切り替え（A2DP↔HFP）で UID が変わる問題に対応
+    AsyncFunction("setPreferredInput") { (uid: String?, name: String?) throws in
       let session = AVAudioSession.sharedInstance()
 
       guard let uid = uid else {
@@ -78,14 +68,24 @@ public class AudioRouteModule: Module {
         return
       }
 
-      guard let inputs = session.availableInputs,
-            let port = inputs.first(where: { $0.uid == uid }) else {
-        // availableInputs に見つからない場合はセッション変更せず何もしない
-        // 音声認識開始時に allowBluetooth が有効になった後に再適用される
+      guard let inputs = session.availableInputs else { return }
+
+      // 1. UID 完全一致を試行
+      if let port = inputs.first(where: { $0.uid == uid }) {
+        try session.setPreferredInput(port)
         return
       }
 
-      try session.setPreferredInput(port)
+      // 2. UID 不一致の場合、デバイス名でフォールバック検索
+      //    Bluetooth プロファイル切り替え（A2DP→HFP）で UID が変わるケースに対応
+      if let name = name,
+         let port = inputs.first(where: { $0.portName == name }) {
+        try session.setPreferredInput(port)
+        return
+      }
+
+      // availableInputs に見つからない場合はセッション変更せず何もしない
+      // 音声認識開始時に allowBluetooth が有効になった後に再適用される
     }
 
     // 優先する出力デバイスを設定する。

--- a/src/hooks/useAudioDeviceRoute.ts
+++ b/src/hooks/useAudioDeviceRoute.ts
@@ -27,9 +27,30 @@ export const useAudioDeviceRoute = () => {
         AudioRoute.getAvailableInputs(),
         AudioRoute.getAvailableOutputs(),
       ])
-      _deviceCache = { inputs, outputs }
-      setAvailableInputs(inputs)
-      setAvailableOutputs(outputs)
+
+      // Bluetooth デバイスは入出力両対応のため、両方のピッカーに表示する（#63）
+      // ユーザーがマイクとしてもスピーカーとしても選択できるようにする
+      const bluetoothTypes = ['BluetoothHFP', 'BluetoothA2DPOutput', 'BluetoothLE']
+      const isBluetooth = (device: AudioPort) =>
+        bluetoothTypes.includes(device.type)
+
+      const mergedInputs = [...inputs]
+      for (const device of outputs.filter(isBluetooth)) {
+        if (!mergedInputs.some((d) => d.uid === device.uid)) {
+          mergedInputs.push(device)
+        }
+      }
+
+      const mergedOutputs = [...outputs]
+      for (const device of inputs.filter(isBluetooth)) {
+        if (!mergedOutputs.some((d) => d.uid === device.uid)) {
+          mergedOutputs.push(device)
+        }
+      }
+
+      _deviceCache = { inputs: mergedInputs, outputs: mergedOutputs }
+      setAvailableInputs(mergedInputs)
+      setAvailableOutputs(mergedOutputs)
     } catch (error) {
       console.error('[useAudioDeviceRoute] refreshDevices failed:', error)
     }
@@ -67,13 +88,15 @@ export const useAudioDeviceRoute = () => {
   const selectInput = useCallback(
     async (uid: string) => {
       try {
-        await AudioRoute.setPreferredInput(uid)
-        storeSetPreferredInput(uid)
+        // 選択されたデバイスの名前を取得して保存（プロファイル切替時のフォールバック用）
+        const device = availableInputs.find((d) => d.uid === uid)
+        await AudioRoute.setPreferredInput(uid, device?.name)
+        storeSetPreferredInput(uid, device?.name)
       } catch (error) {
         console.error('[useAudioDeviceRoute] selectInput failed:', error)
       }
     },
-    [storeSetPreferredInput]
+    [storeSetPreferredInput, availableInputs]
   )
 
   const selectOutput = useCallback(

--- a/src/hooks/useVoiceRecognition.ts
+++ b/src/hooks/useVoiceRecognition.ts
@@ -60,6 +60,11 @@ export const useVoiceRecognition = (
   const isSessionActiveRef = useRef(false)
   const recognitionStateRef = useRef(recognitionState)
   const isOnlineRef = useRef(isOnline)
+  // ウェイクワード検出時のトランスクリプトを記録し、
+  // コマンドマッチング時は新しいテキストのみを対象にする（#63）
+  // continuous モードでトランスクリプトが蓄積されると、前回のコマンド（例: 「再生」）が
+  // 残り続け、常に PLAY がマッチする問題を防ぐ
+  const wakeWordTranscriptRef = useRef('')
 
   useEffect(() => {
     isOnlineRef.current = isOnline
@@ -158,21 +163,32 @@ export const useVoiceRecognition = (
     // expo-speech-recognition が setCategory + setActive を完了したタイミングで
     // preferredInput を適用する。allowBluetooth が有効な状態で呼ぶため
     // Bluetooth マイクが availableInputs に含まれ setPreferredInput が成功する
+    // セッション開始イベント:
+    // expo-speech-recognition が setCategory(.playAndRecord, .allowBluetooth) + setActive を
+    // 完了したタイミング。このタイミングで初めて Bluetooth マイクが availableInputs に出現するため、
+    // setPreferredInput をここで適用する。
+    // UID 不一致時（プロファイル切替で UID が変わった場合）は名前でフォールバックする（#63）
     const startSubscription = ExpoSpeechRecognitionModule.addListener(
       'start',
       async () => {
         isSessionActiveRef.current = true
 
         try {
-          const { preferredInputUID } = useAudioDeviceStore.getState()
+          const { preferredInputUID, preferredInputName } =
+            useAudioDeviceStore.getState()
           if (preferredInputUID) {
-            await AudioRoute.setPreferredInput(preferredInputUID)
+            // UID + 名前を渡す。ネイティブ側で UID 一致を試行し、
+            // 失敗時は名前でフォールバック検索する
+            await AudioRoute.setPreferredInput(
+              preferredInputUID,
+              preferredInputName
+            )
           } else {
             // 明示的に選択されていない場合は最初の利用可能デバイスを自動選択
             // （開発用: 内蔵マイクはフィルタ済みなので外部デバイスが優先される）
             const inputs = await AudioRoute.getAvailableInputs()
             if (inputs.length > 0) {
-              await AudioRoute.setPreferredInput(inputs[0].uid)
+              await AudioRoute.setPreferredInput(inputs[0].uid, inputs[0].name)
             }
           }
         } catch (err) {
@@ -197,6 +213,9 @@ export const useVoiceRecognition = (
           recognitionStateRef.current === VoiceRecognitionState.LISTENING_FOR_WAKEWORD
         ) {
           if (containsWakeWord(transcript)) {
+            // ウェイクワード検出時のトランスクリプトを記録（#63）
+            // コマンドマッチング時にこの部分を除外し、蓄積テキストによる誤マッチを防ぐ
+            wakeWordTranscriptRef.current = transcript
             updateState(VoiceRecognitionState.LISTENING_FOR_COMMAND)
 
             clearCommandTimeout()
@@ -214,7 +233,18 @@ export const useVoiceRecognition = (
         } else if (
           recognitionStateRef.current === VoiceRecognitionState.LISTENING_FOR_COMMAND
         ) {
-          const command = matchCommand(transcript)
+          // continuous モードではトランスクリプトが蓄積される場合がある（#63）
+          // ウェイクワード部分を除外して新しいテキストのみでコマンドマッチングする
+          // これにより前回の「再生」等が残って常にPLAYがマッチする問題を防ぐ
+          let commandText = transcript
+          const wakeWordPart = wakeWordTranscriptRef.current
+          if (wakeWordPart && transcript.startsWith(wakeWordPart)) {
+            commandText = transcript.substring(wakeWordPart.length).trim()
+          }
+          // commandText が空の場合はまだ新しいテキストがない（ウェイクワードの確定イベント等）
+          if (!commandText) return
+
+          const command = matchCommand(commandText)
           if (command) {
             clearCommandTimeout()
             updateState(VoiceRecognitionState.PROCESSING)

--- a/src/screens/MainScreen.tsx
+++ b/src/screens/MainScreen.tsx
@@ -40,15 +40,17 @@ export const MainScreen: React.FC<Props> = ({ navigation }) => {
     const previousState = previousRecognitionStateRef.current
     previousRecognitionStateRef.current = recognitionState
 
-    const wasListeningOrProcessing =
-      previousState === VoiceRecognitionState.LISTENING_FOR_COMMAND ||
-      previousState === VoiceRecognitionState.PROCESSING
+    // コマンド未検出時のみスナックバーを表示する（#63）
+    // LISTENING_FOR_COMMAND → WAKEWORD/IDLE: タイムアウト（コマンド未検出）→ スナックバー表示
+    // PROCESSING → WAKEWORD: コマンド検出・処理済み → スナックバーは表示しない
+    const wasListeningForCommand =
+      previousState === VoiceRecognitionState.LISTENING_FOR_COMMAND
 
     const isNowIdle =
       recognitionState === VoiceRecognitionState.IDLE ||
       recognitionState === VoiceRecognitionState.LISTENING_FOR_WAKEWORD
 
-    if (wasListeningOrProcessing && isNowIdle) {
+    if (wasListeningForCommand && isNowIdle) {
       const lastText = useVoiceStore.getState().lastRecognizedText
       if (lastText === null) {
         setIsFailureSnackbarVisible(true)

--- a/src/stores/audioDeviceStore.ts
+++ b/src/stores/audioDeviceStore.ts
@@ -5,12 +5,13 @@ import { STORAGE_KEYS } from '../constants/defaults'
 
 interface AudioDeviceState {
   preferredInputUID: string | null
+  preferredInputName: string | null
   preferredOutputUID: string | null
   isManuallySet: boolean
 }
 
 interface AudioDeviceActions {
-  setPreferredInput: (uid: string | null) => void
+  setPreferredInput: (uid: string | null, name?: string | null) => void
   setPreferredOutput: (uid: string | null) => void
   resetToAuto: () => void
 }
@@ -19,11 +20,16 @@ export const useAudioDeviceStore = create<AudioDeviceState & AudioDeviceActions>
   persist(
     (set) => ({
       preferredInputUID: null,
+      preferredInputName: null,
       preferredOutputUID: null,
       isManuallySet: false,
 
-      setPreferredInput: (uid) =>
-        set({ preferredInputUID: uid, isManuallySet: true }),
+      setPreferredInput: (uid, name) =>
+        set({
+          preferredInputUID: uid,
+          preferredInputName: name ?? null,
+          isManuallySet: true,
+        }),
 
       setPreferredOutput: (uid) =>
         set({ preferredOutputUID: uid, isManuallySet: true }),
@@ -31,6 +37,7 @@ export const useAudioDeviceStore = create<AudioDeviceState & AudioDeviceActions>
       resetToAuto: () =>
         set({
           preferredInputUID: null,
+          preferredInputName: null,
           preferredOutputUID: null,
           isManuallySet: false,
         }),


### PR DESCRIPTION
## Summary
- Bluetooth デバイスをマイク/スピーカー両方のピッカーに表示するよう変更（A2DP フォールバックの偽 HFP エントリを削除）
- 音声コマンドの蓄積テキスト問題を修正（ウェイクワード部分を除外して新テキストのみでマッチング）
- Bluetooth マイクルーティングに名前ベースのフォールバック検索を追加（プロファイル切替時の UID 不一致に対応）

## 変更ファイル（7ファイル）

| ファイル | 変更内容 |
|---|---|
| `AudioRouteModule.swift` | A2DP フォールバック削除、setPreferredInput に名前フォールバック追加 |
| `modules/audio-route/index.ts` | setPreferredInput に name パラメータ追加 |
| `audioDeviceStore.ts` | preferredInputName フィールド追加 |
| `useAudioDeviceRoute.ts` | Bluetooth デバイスを両ピッカーに統合、デバイス名保存 |
| `useVoiceRecognition.ts` | wakeWordTranscriptRef で蓄積テキスト除外、名前フォールバック |
| `MainScreen.tsx` | スナックバーを LISTENING_FOR_COMMAND→WAKEWORD のみに限定 |
| `ios-audio-session-behavior.md` | 新事実（セクション7, 8）を追記 |

## Test plan
- [ ] Bluetooth スピーカーとイヤホン2台接続時、両方のピッカーに Bluetooth デバイスが表示される
- [ ] 「再生」コマンド後に「停止」「次」「前」等が正常に実行される
- [ ] Bluetooth イヤホンをマイクに選択した場合、内蔵マイクではなくイヤホンマイクが使用される
- [ ] 設定画面を開いただけで音楽が途切れない
- [ ] フィードバック音が正常に再生される
- [ ] 成功したコマンド後に「認識できませんでした」スナックバーが表示されない

## ネイティブビルド
**必要**（AudioRouteModule.swift を変更）

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)