### PR TITLE
[Fix] Bluetoothマイクルーティングの根本修正とデバイス一覧改善

### DIFF
--- a/docs/ios-audio-session-behavior.md
+++ b/docs/ios-audio-session-behavior.md
@@ -146,6 +146,45 @@ AI がオーディオ関連のバグを修正する際、推測ではなくこ�
 
 ---
 
+## 9. expo-speech-recognition の AVAudioEngine 入力キャプチャタイミング
+
+### 確認済みの事実
+
+- `expo-speech-recognition` の `start()` 内部フロー:
+  1. `setupAudioSession()` → `setCategory` + `setActive`
+  2. `AVAudioEngine()` 作成 → `inputNode` が**この時点の**入力デバイスをキャプチャ
+  3. `prepareEngine()` → `engine.prepare()` + `engine.start()`
+  4. `startHandler()` 発火（= `start` イベント）
+- `start` イベント後に `setPreferredInput` を呼んでも、`AVAudioEngine.inputNode` は既に作成済みなので**マイクルーティングに反映されない**（#65 で判明）
+- `setPreferredInput` を `start()` の**前**に呼ぶ必要がある
+- ただし、`allowBluetooth` 未設定の状態では Bluetooth デバイスが `availableInputs` に含まれない（セクション3参照）
+- **解決策**: `start()` の前に同じカテゴリ（`playAndRecord` + `allowBluetooth`）で `setCategory` + `setActive` + `setPreferredInput` を呼ぶ。expo-speech-recognition 側の `setCategory` は同一設定なら no-op になり、`preferredInput` が維持される
+
+### 対策（現在の実装）
+
+- `AudioRouteModule.swift` に `prepareSessionForRecognition` を追加（#65）
+- `useVoiceRecognition` の `startRecognition` で `ExpoSpeechRecognitionModule.start()` の前に `prepareSessionForRecognition` を呼ぶ
+- `start` イベントリスナーはバックアップとして残す（`prepareSessionForRecognition` が何らかの理由で失敗した場合のフォールバック）
+
+---
+
+## 10. iOS の availableOutputs API の不在
+
+### 確認済みの事実
+
+- iOS には `availableInputs` に相当する `availableOutputs` API が**存在しない**
+- 出力デバイスの列挙は `currentRoute.outputs` でしか取得できないが、これは**現在アクティブな**出力のみ
+- A2DP 出力専用デバイス（Bluetooth スピーカー等）が非アクティブの場合、どの API からも取得できない
+- Bluetooth HFP/LE デバイスは入出力両対応のため `availableInputs` から検出可能
+
+### 対策（現在の実装）
+
+- `getAvailableOutputs` で `currentRoute.outputs` に加え、`availableInputs` の HFP/LE デバイスも列挙（#65）
+- TS 層で Bluetooth デバイスを入出力両方のピッカーにマージ表示
+- A2DP 専用デバイスがアクティブ出力でない場合は検出できない制限を許容
+
+---
+
 ## 追記ルール
 
 新しい事実が判明した場合、以下の形式で追記すること:

--- a/modules/audio-route/index.ts
+++ b/modules/audio-route/index.ts
@@ -25,6 +25,16 @@ export const setPreferredInput = (
 export const setPreferredOutput = (uid: string): Promise<void> =>
   AudioRouteNativeModule?.setPreferredOutput(uid) ?? Promise.resolve()
 
+// 音声認識開始前に audio session を設定し Bluetooth マイクを preferred input にする（#65）
+// expo-speech-recognition の start() 前に呼ぶことで、AVAudioEngine が
+// 正しい Bluetooth 入力デバイスをキャプチャする
+export const prepareSessionForRecognition = (
+  uid: string | null,
+  name?: string | null
+): Promise<void> =>
+  AudioRouteNativeModule?.prepareSessionForRecognition(uid, name ?? null) ??
+  Promise.resolve()
+
 export const getCurrentRoute = (): Promise<{
   inputs: AudioPort[]
   outputs: AudioPort[]

--- a/modules/audio-route/ios/AudioRouteModule.swift
+++ b/modules/audio-route/ios/AudioRouteModule.swift
@@ -31,21 +31,45 @@ public class AudioRouteModule: Module {
     }
 
     // 利用可能な出力デバイス一覧を返す
-    // 内蔵スピーカーは常に含める。現在接続中の外部デバイス（Bluetooth/有線）も列挙。
+    // 1. currentRoute.outputs から現在アクティブな外部デバイスを列挙
+    // 2. availableInputs から HFP 双方向デバイスを追加（#65）
+    //    HFP デバイスは入出力両対応だが currentRoute.outputs に出ない場合がある
+    //    （例: A2DP で別デバイスが出力中の場合）
+    // 3. 内蔵スピーカーは常に含める
     AsyncFunction("getAvailableOutputs") { () -> [[String: String]] in
+      let session = AVAudioSession.sharedInstance()
       var outputs: [[String: String]] = []
+      var seenUIDs = Set<String>()
 
-      let currentOutputs = AVAudioSession.sharedInstance().currentRoute.outputs
-      for port in currentOutputs {
+      // 1. 現在アクティブな出力デバイス
+      for port in session.currentRoute.outputs {
         if port.portType != .builtInSpeaker {
           outputs.append([
             "uid": port.uid,
             "name": port.portName,
             "type": port.portType.rawValue,
           ])
+          seenUIDs.insert(port.uid)
         }
       }
 
+      // 2. availableInputs に含まれる Bluetooth HFP/LE デバイスは双方向なので
+      //    出力としても選択可能。currentRoute に出ていないものを追加する
+      if let inputs = session.availableInputs {
+        let btInputTypes: [AVAudioSession.Port] = [.bluetoothHFP, .bluetoothLE]
+        for port in inputs where btInputTypes.contains(port.portType) {
+          if !seenUIDs.contains(port.uid) {
+            outputs.append([
+              "uid": port.uid,
+              "name": port.portName,
+              "type": port.portType.rawValue,
+            ])
+            seenUIDs.insert(port.uid)
+          }
+        }
+      }
+
+      // 3. 内蔵スピーカーは常に含める
       outputs.append([
         "uid": "builtin_speaker",
         "name": "内蔵スピーカー",
@@ -98,6 +122,46 @@ public class AudioRouteModule: Module {
         try session.overrideOutputAudioPort(.speaker)
       } else {
         try session.overrideOutputAudioPort(.none)
+      }
+    }
+
+    // 音声認識開始前に audio session を設定し、Bluetooth マイクを preferred input に設定する（#65）
+    //
+    // expo-speech-recognition の内部フロー:
+    //   1. setupAudioSession() → setCategory + setActive
+    //   2. AVAudioEngine() → inputNode が「この時点の」入力デバイスをキャプチャ
+    //   3. audioEngine.start()
+    //   4. startHandler() → ← ここで setPreferredInput しても手遅れ
+    //
+    // この関数を ExpoSpeechRecognitionModule.start() の前に呼ぶことで:
+    //   - setCategory(.playAndRecord, allowBluetooth) が先に実行される
+    //   - Bluetooth デバイスが availableInputs に出現する
+    //   - setPreferredInput で Bluetooth マイクが設定される
+    //   - expo-speech-recognition が同じ category を設定 → no-op（preferredInput 維持）
+    //   - AVAudioEngine.inputNode が Bluetooth マイクをキャプチャする
+    AsyncFunction("prepareSessionForRecognition") { (uid: String?, name: String?) throws in
+      let session = AVAudioSession.sharedInstance()
+
+      // expo-speech-recognition と同じカテゴリ・オプションを設定
+      // 先に設定しておくことで、expo-speech-recognition 側の setCategory は no-op になる
+      try session.setCategory(
+        .playAndRecord,
+        mode: .default,
+        options: [.allowBluetooth, .allowBluetoothA2DP, .defaultToSpeaker, .mixWithOthers]
+      )
+      try session.setActive(true, options: .notifyOthersOnDeactivation)
+
+      // allowBluetooth が有効な状態で setPreferredInput を実行
+      // この時点で availableInputs に Bluetooth デバイスが含まれている
+      guard let uid = uid else { return }
+      guard let inputs = session.availableInputs else { return }
+
+      // UID 完全一致 → 名前フォールバック（プロファイル切替で UID 変更時）
+      if let port = inputs.first(where: { $0.uid == uid }) {
+        try session.setPreferredInput(port)
+      } else if let name = name,
+                let port = inputs.first(where: { $0.portName == name }) {
+        try session.setPreferredInput(port)
       }
     }
 

--- a/src/hooks/useVoiceRecognition.ts
+++ b/src/hooks/useVoiceRecognition.ts
@@ -125,8 +125,26 @@ export const useVoiceRecognition = (
     }
   }, [])
 
-  const startRecognition = useCallback(() => {
+  const startRecognition = useCallback(async () => {
     try {
+      // Bluetooth マイクルーティングの根本修正（#65）
+      // expo-speech-recognition は内部で:
+      //   1. setCategory + setActive
+      //   2. AVAudioEngine() → inputNode が「この時点の」入力をキャプチャ
+      //   3. engine.start()
+      //   4. startHandler() 発火
+      // のため、start() 前に audio session を設定して preferred input を適用する必要がある。
+      // 同じ category を先に設定しておくと expo-speech-recognition 側は no-op になり、
+      // AVAudioEngine 作成時に正しい Bluetooth 入力がキャプチャされる。
+      const { preferredInputUID, preferredInputName } =
+        useAudioDeviceStore.getState()
+      if (preferredInputUID) {
+        await AudioRoute.prepareSessionForRecognition(
+          preferredInputUID,
+          preferredInputName
+        )
+      }
+
       ExpoSpeechRecognitionModule.start({
         lang: 'ja-JP',
         interimResults: true,
@@ -159,15 +177,11 @@ export const useVoiceRecognition = (
   }, [updateState, startRecognition])
 
   useEffect(() => {
-    // セッション開始イベント:
-    // expo-speech-recognition が setCategory + setActive を完了したタイミングで
-    // preferredInput を適用する。allowBluetooth が有効な状態で呼ぶため
-    // Bluetooth マイクが availableInputs に含まれ setPreferredInput が成功する
-    // セッション開始イベント:
-    // expo-speech-recognition が setCategory(.playAndRecord, .allowBluetooth) + setActive を
-    // 完了したタイミング。このタイミングで初めて Bluetooth マイクが availableInputs に出現するため、
-    // setPreferredInput をここで適用する。
-    // UID 不一致時（プロファイル切替で UID が変わった場合）は名前でフォールバックする（#63）
+    // セッション開始イベント（#65 で役割変更）:
+    // prepareSessionForRecognition で既に preferred input を設定済みだが、
+    // バックアップとして start 後にも setPreferredInput を呼ぶ。
+    // また、allowBluetooth が有効な状態で availableInputs を確認し、
+    // ストアの UID が古い場合（プロファイル切替等）に最新 UID に更新する。
     const startSubscription = ExpoSpeechRecognitionModule.addListener(
       'start',
       async () => {
@@ -177,15 +191,29 @@ export const useVoiceRecognition = (
           const { preferredInputUID, preferredInputName } =
             useAudioDeviceStore.getState()
           if (preferredInputUID) {
-            // UID + 名前を渡す。ネイティブ側で UID 一致を試行し、
-            // 失敗時は名前でフォールバック検索する
+            // バックアップ: start 後にも setPreferredInput を適用
+            // prepareSessionForRecognition が成功していれば既に設定済みだが、
+            // 何らかの理由で失敗した場合のフォールバック
             await AudioRoute.setPreferredInput(
               preferredInputUID,
               preferredInputName
             )
+
+            // allowBluetooth 有効状態で最新の availableInputs を確認し、
+            // ストアの UID を最新に更新（名前マッチで見つかった場合）
+            if (preferredInputName) {
+              const freshInputs = await AudioRoute.getAvailableInputs()
+              const matchByName = freshInputs.find(
+                (d) => d.name === preferredInputName
+              )
+              if (matchByName && matchByName.uid !== preferredInputUID) {
+                useAudioDeviceStore
+                  .getState()
+                  .setPreferredInput(matchByName.uid, matchByName.name)
+              }
+            }
           } else {
             // 明示的に選択されていない場合は最初の利用可能デバイスを自動選択
-            // （開発用: 内蔵マイクはフィルタ済みなので外部デバイスが優先される）
             const inputs = await AudioRoute.getAvailableInputs()
             if (inputs.length > 0) {
               await AudioRoute.setPreferredInput(inputs[0].uid, inputs[0].name)


### PR DESCRIPTION
## Summary

- **Bluetoothマイクルーティング**: `expo-speech-recognition` の `start()` 前に `prepareSessionForRecognition` で `setCategory` + `setPreferredInput` を実行し、`AVAudioEngine` が正しい Bluetooth 入力をキャプチャするよう修正
- **Bluetoothデバイス一覧**: `getAvailableOutputs` で `availableInputs` の HFP/LE デバイスも列挙し、出力ピッカーに Bluetooth デバイスが表示されない問題を修正
- **ドキュメント**: `docs/ios-audio-session-behavior.md` にセクション 9（AVAudioEngine タイミング）、10（availableOutputs API 不在）を追記

## Root Cause

### マイクルーティング
`expo-speech-recognition` は内部で `AVAudioEngine()` 作成時に `inputNode` が**その時点の**入力デバイスをキャプチャする。従来の `start` イベント後の `setPreferredInput` では手遅れだった。

### デバイス一覧
iOS には `availableOutputs` API が存在せず、`currentRoute.outputs` は現在アクティブな出力のみ返す。HFP/LE デバイスは `availableInputs` から検出可能だが、従来はこれを利用していなかった。

## Changed Files

| File | Change |
|---|---|
| `modules/audio-route/ios/AudioRouteModule.swift` | `prepareSessionForRecognition` 追加、`getAvailableOutputs` 改善 |
| `modules/audio-route/index.ts` | `prepareSessionForRecognition` TS エクスポート追加 |
| `src/hooks/useVoiceRecognition.ts` | `startRecognition` を async 化、`start` 前に `prepareSessionForRecognition` 呼び出し |
| `docs/ios-audio-session-behavior.md` | セクション 9, 10 追記 |

## Test plan

- [ ] Bluetooth イヤホン接続時、設定画面の出力ピッカーにデバイスが表示される
- [ ] Bluetooth イヤホン接続時、音声認識が Bluetooth マイクで動作する（内蔵マイクでなく）
- [ ] 音楽再生中に音声認識を開始しても音質が大幅に低下しない
- [ ] 内蔵マイクのみの場合も正常に音声認識が動作する

## Build

⚠️ **ネイティブビルドが必要です**（`AudioRouteModule.swift` に新しい関数を追加）

```bash
npx expo prebuild --clean && npx expo run:ios
```

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)