### PR TITLE
[Fix] expo-speech-recognitionパッチでBluetoothマイクルーティング根本修正

### DIFF
--- a/docs/ios-audio-session-behavior.md
+++ b/docs/ios-audio-session-behavior.md
@@ -216,8 +216,28 @@ AI がオーディオ関連のバグを修正する際、推測ではなくこ�
 ### 対策（現在の実装）
 
 - `AVAudioSession.routeChangeNotification` を監視し、A2DP デバイスをモジュールレベルでキャッシュ（#67）
+- デバイス切断時（`oldDeviceUnavailable`）はキャッシュから該当デバイスを削除
 - `getAvailableOutputs` でキャッシュされた A2DP デバイスも含めて返す
 - TS 層では A2DP デバイスをスピーカーピッカーのみに表示（マイク非対応のため入力ピッカーには含めない）
+- ルート変更イベントを JS 層に `onAudioRouteChange` として発行し、デバイスリストを自動更新
+
+---
+
+## 13. expo-speech-recognition の setCategory() が preferredInput をリセットする問題
+
+### 確認済みの事実
+
+- `expo-speech-recognition` の `prepareMicrophoneRecognition()` は内部で `setupAudioSession()` → `AVAudioEngine()` を連続実行
+- `setupAudioSession()` 内の `setCategory()` は、同一パラメータであっても `preferredInput` をリセットする可能性がある（iOS 16+ で確認）
+- `prepareSessionForRecognition` で事前に `setPreferredInput` を設定しても、ライブラリの `setCategory()` でリセットされる
+- 結果として `AVAudioEngine.inputNode` は内蔵マイクをキャプチャしてしまう
+
+### 対策（現在の実装）
+
+- `expo-speech-recognition` を `patch-package` でパッチし、`setupAudioSession()` と `AVAudioEngine()` の間で `setPreferredInput` を再適用（#67）
+- `SpeechRecognitionOptions` に `iosPreferredInputUID` / `iosPreferredInputName` フィールドを追加
+- `restartAudioEngineForRouteChange()` でも同様に `setPreferredInput` を再適用
+- JS 側から `ExpoSpeechRecognitionModule.start()` に新フィールドを渡す
 
 ---
 

--- a/modules/audio-route/index.ts
+++ b/modules/audio-route/index.ts
@@ -1,12 +1,24 @@
-import { requireOptionalNativeModule } from 'expo-modules-core'
+import {
+  requireOptionalNativeModule,
+  EventEmitter,
+} from 'expo-modules-core'
 
 // ネイティブモジュールが未ビルドの場合は null になる（prebuild 前の開発時など）
 const AudioRouteNativeModule = requireOptionalNativeModule('AudioRoute')
+
+// イベントエミッター（ルート変更通知の購読用）
+const emitter = AudioRouteNativeModule
+  ? new EventEmitter(AudioRouteNativeModule)
+  : null
 
 export interface AudioPort {
   uid: string
   name: string
   type: string
+}
+
+export interface AudioRouteChangeEvent {
+  reason: string
 }
 
 export const getAvailableInputs = (): Promise<AudioPort[]> =>
@@ -41,3 +53,15 @@ export const getCurrentRoute = (): Promise<{
 }> =>
   AudioRouteNativeModule?.getCurrentRoute() ??
   Promise.resolve({ inputs: [], outputs: [] })
+
+// オーディオルート変更イベントの購読（#67）
+// TrackPlayer の再生開始、Bluetooth デバイスの接続/切断 等で発火する
+export const addRouteChangeListener = (
+  callback: (event: AudioRouteChangeEvent) => void
+): { remove: () => void } | null => {
+  if (!emitter) return null
+  return emitter.addListener(
+    'onAudioRouteChange' as never,
+    callback as never
+  )
+}

--- a/modules/audio-route/ios/AudioRouteModule.swift
+++ b/modules/audio-route/ios/AudioRouteModule.swift
@@ -9,8 +9,11 @@ public class AudioRouteModule: Module {
   // 非アクティブな A2DP デバイスを追跡できない。
   private static var knownA2DPDevices: [[String: String]] = []
   private static var routeChangeObserverRegistered = false
+  // イベント送信用のモジュールインスタンス参照
+  private static weak var moduleInstance: AudioRouteModule?
 
   /// ルート変更通知を監視し、A2DP デバイスをキャッシュに追加する
+  /// またルート変更イベントを JS 層に発行する（#67）
   private static func registerRouteChangeObserverIfNeeded() {
     guard !routeChangeObserverRegistered else { return }
     routeChangeObserverRegistered = true
@@ -19,8 +22,26 @@ public class AudioRouteModule: Module {
       forName: AVAudioSession.routeChangeNotification,
       object: nil,
       queue: .main
-    ) { _ in
+    ) { notification in
+      let reason = notification.userInfo?[AVAudioSessionRouteChangeReasonKey] as? UInt
+      let reasonEnum = AVAudioSession.RouteChangeReason(rawValue: reason ?? 0)
+
+      // デバイス切断時は A2DP キャッシュから該当デバイスを削除
+      if reasonEnum == .oldDeviceUnavailable {
+        if let previousRoute = notification.userInfo?[AVAudioSessionRouteChangePreviousRouteKey] as? AVAudioSessionRouteDescription {
+          for port in previousRoute.outputs where port.portType == .bluetoothA2DP {
+            Self.knownA2DPDevices.removeAll { $0["name"] == port.portName }
+          }
+        }
+      }
+
       Self.updateKnownA2DPDevices()
+
+      // JS 層にルート変更イベントを発行
+      // useAudioDeviceRoute がこれを受けてデバイスリストを再取得する
+      Self.moduleInstance?.sendEvent("onAudioRouteChange", [
+        "reason": Self.routeChangeReasonString(reasonEnum),
+      ])
     }
 
     // 初回登録時に現在のルートからもキャッシュ
@@ -28,9 +49,6 @@ public class AudioRouteModule: Module {
   }
 
   /// currentRoute.outputs から A2DP デバイスを knownA2DPDevices に追加する
-  /// 既に接続解除されたデバイスは availableInputs にも currentRoute にも現れなくなるが、
-  /// 接続中のデバイスが一時的に currentRoute から外れるケースをカバーする。
-  /// 完全に切断されたデバイスは getAvailableOutputs で接続チェック時に除外される。
   private static func updateKnownA2DPDevices() {
     let session = AVAudioSession.sharedInstance()
     for port in session.currentRoute.outputs {
@@ -48,8 +66,28 @@ public class AudioRouteModule: Module {
     }
   }
 
+  /// RouteChangeReason を文字列に変換
+  private static func routeChangeReasonString(_ reason: AVAudioSession.RouteChangeReason?) -> String {
+    switch reason {
+    case .newDeviceAvailable: return "newDeviceAvailable"
+    case .oldDeviceUnavailable: return "oldDeviceUnavailable"
+    case .categoryChange: return "categoryChange"
+    case .override: return "override"
+    case .routeConfigurationChange: return "routeConfigurationChange"
+    default: return "unknown"
+    }
+  }
+
   public func definition() -> ModuleDefinition {
     Name("AudioRoute")
+
+    // モジュールインスタンスを保持（イベント送信用）
+    OnCreate {
+      Self.moduleInstance = self
+    }
+
+    // JS 層に発行するイベント定義（#67）
+    Events("onAudioRouteChange")
 
     // 接続済み入力デバイス（マイク）一覧を返す
     // 開発用: 内蔵マイクは除外し外部デバイスのみ返す
@@ -210,6 +248,10 @@ public class AudioRouteModule: Module {
     // HFP は入出力同期プロトコルであり、.defaultToSpeaker が出力を内蔵スピーカーに
     // 強制すると iOS が HFP 同期を維持できず setPreferredInput を無視する。
     // ref: Apple Developer Forums #713197, #730600
+    //
+    // 追加で expo-speech-recognition のパッチにより、ライブラリ内部でも
+    // setupAudioSession() と AVAudioEngine() の間で setPreferredInput が呼ばれる。
+    // この関数は事前準備として category 設定と preferredInput を先に適用しておく。
     AsyncFunction("prepareSessionForRecognition") { (uid: String?, name: String?) throws in
       let session = AVAudioSession.sharedInstance()
 
@@ -217,10 +259,6 @@ public class AudioRouteModule: Module {
       let isBluetooth = Self.isBluetoothDevice(uid: uid, name: name, session: session)
 
       // .defaultToSpeaker は Bluetooth HFP マイクルーティングと競合する（#67）
-      // HFP は入出力が同期されるため、.defaultToSpeaker が出力を内蔵スピーカーに強制すると
-      // iOS が Bluetooth マイクの setPreferredInput を無視してしまう。
-      // Bluetooth マイク選択時は .defaultToSpeaker を除外し、HFP の入出力同期を維持する。
-      // Bluetooth 未選択時は .defaultToSpeaker を含めて、受話器ではなくスピーカーから出力する。
       var categoryOptions: AVAudioSession.CategoryOptions = [
         .allowBluetooth, .allowBluetoothA2DP, .mixWithOthers
       ]
@@ -228,8 +266,6 @@ public class AudioRouteModule: Module {
         categoryOptions.insert(.defaultToSpeaker)
       }
 
-      // expo-speech-recognition と同じカテゴリ・オプションを設定
-      // 先に設定しておくことで、expo-speech-recognition 側の setCategory は no-op になる
       try session.setCategory(
         .playAndRecord,
         mode: .default,
@@ -238,7 +274,6 @@ public class AudioRouteModule: Module {
       try session.setActive(true, options: .notifyOthersOnDeactivation)
 
       // allowBluetooth が有効な状態で setPreferredInput を実行
-      // この時点で availableInputs に Bluetooth デバイスが含まれている
       guard let uid = uid else { return }
       guard let inputs = session.availableInputs else { return }
 
@@ -273,20 +308,17 @@ public class AudioRouteModule: Module {
   }
 
   // 指定されたデバイスが Bluetooth デバイスかどうかを判定する（#67）
-  // availableInputs で UID または名前が Bluetooth ポートタイプに一致するかチェック
   private static func isBluetoothDevice(uid: String?, name: String?, session: AVAudioSession) -> Bool {
     guard let uid = uid else { return false }
     guard let inputs = session.availableInputs else { return false }
 
     let btTypes: [AVAudioSession.Port] = [.bluetoothHFP, .bluetoothLE, .bluetoothA2DP]
 
-    // UID で検索
     if let port = inputs.first(where: { $0.uid == uid }),
        btTypes.contains(port.portType) {
       return true
     }
 
-    // 名前で検索（プロファイル切替で UID が変わるケース）
     if let name = name,
        let port = inputs.first(where: { $0.portName == name }),
        btTypes.contains(port.portType) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@types/react": "~19.2.2",
         "jest": "^30.2.0",
         "jest-expo": "^55.0.9",
+        "patch-package": "^8.0.1",
         "ts-jest": "^29.4.6",
         "typescript": "~5.9.2"
       }
@@ -4771,6 +4772,13 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/abab": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -5321,6 +5329,25 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -5333,6 +5360,23 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -5815,6 +5859,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/define-lazy-prop": {
@@ -6896,6 +6958,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/flow-enums-runtime": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/flow-enums-runtime/-/flow-enums-runtime-0.0.6.tgz",
@@ -6962,6 +7034,31 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/fs-extra/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/fs.realpath": {
@@ -7156,6 +7253,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
@@ -7556,6 +7666,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -11832,6 +11949,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -11842,6 +11979,49 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonfile/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/kleur": {
@@ -12886,6 +13066,16 @@
         "node": ">=20.19.4"
       }
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -13147,6 +13337,62 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^10.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.2.4",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/patch-package/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/path-exists": {
@@ -14344,6 +14590,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -14925,6 +15189,16 @@
       "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
       "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
       "license": "MIT"
+    },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
     },
     "node_modules/tmpl": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "test": "jest"
+    "test": "jest",
+    "postinstall": "patch-package"
   },
   "jest": {
     "preset": "ts-jest",
@@ -33,6 +34,7 @@
     "@react-navigation/drawer": "^7.9.4",
     "@react-navigation/native": "^7.1.33",
     "@react-navigation/native-stack": "^7.14.4",
+    "audio-route": "file:./modules/audio-route",
     "expo": "~55.0.5",
     "expo-audio": "~55.0.8",
     "expo-document-picker": "^55.0.8",
@@ -48,8 +50,7 @@
     "react-native-screens": "^4.24.0",
     "react-native-track-player": "^4.1.2",
     "react-native-worklets": "^0.7.4",
-    "zustand": "^5.0.11",
-    "audio-route": "file:./modules/audio-route"
+    "zustand": "^5.0.11"
   },
   "devDependencies": {
     "@testing-library/react-native": "^13.3.3",
@@ -57,6 +58,7 @@
     "@types/react": "~19.2.2",
     "jest": "^30.2.0",
     "jest-expo": "^55.0.9",
+    "patch-package": "^8.0.1",
     "ts-jest": "^29.4.6",
     "typescript": "~5.9.2"
   },

--- a/patches/expo-speech-recognition+3.1.1.patch
+++ b/patches/expo-speech-recognition+3.1.1.patch
@@ -1,0 +1,69 @@
+diff --git a/node_modules/expo-speech-recognition/ios/ExpoSpeechRecognizer.swift b/node_modules/expo-speech-recognition/ios/ExpoSpeechRecognizer.swift
+index 282f1c9..c9f69fd 100644
+--- a/node_modules/expo-speech-recognition/ios/ExpoSpeechRecognizer.swift
++++ b/node_modules/expo-speech-recognition/ios/ExpoSpeechRecognizer.swift
+@@ -335,6 +335,24 @@ actor ExpoSpeechRecognizer: ObservableObject {
+     options: SpeechRecognitionOptions
+   ) throws {
+     try Self.setupAudioSession(options.iosCategory)
++
++    // autopl パッチ (#67): setupAudioSession() と AVAudioEngine() の間で
++    // setPreferredInput を呼ぶ。これにより AVAudioEngine.inputNode が
++    // 正しい Bluetooth マイクをキャプチャする。
++    // setupAudioSession() の setCategory() が preferredInput をリセットする
++    // 可能性があるため、ここで再設定する必要がある。
++    if let preferredUID = options.iosPreferredInputUID {
++      let session = AVAudioSession.sharedInstance()
++      if let inputs = session.availableInputs {
++        if let port = inputs.first(where: { $0.uid == preferredUID }) {
++          try session.setPreferredInput(port)
++        } else if let preferredName = options.iosPreferredInputName,
++                  let port = inputs.first(where: { $0.portName == preferredName }) {
++          try session.setPreferredInput(port)
++        }
++      }
++    }
++
+     registerAudioSessionObservers()
+     self.audioEngine = AVAudioEngine()
+ 
+@@ -779,6 +797,19 @@ actor ExpoSpeechRecognizer: ObservableObject {
+       oldEngine.reset()
+     }
+ 
++    // autopl パッチ (#67): ルート変更後のエンジン再作成でも setPreferredInput を再適用
++    if let preferredUID = options.iosPreferredInputUID {
++      let session = AVAudioSession.sharedInstance()
++      if let inputs = session.availableInputs {
++        if let port = inputs.first(where: { $0.uid == preferredUID }) {
++          try? session.setPreferredInput(port)
++        } else if let preferredName = options.iosPreferredInputName,
++                  let port = inputs.first(where: { $0.portName == preferredName }) {
++          try? session.setPreferredInput(port)
++        }
++      }
++    }
++
+     let newEngine = AVAudioEngine()
+     let inputNode = newEngine.inputNode
+     let audioFormat = Self.getAudioFormat(forEngine: newEngine)
+diff --git a/node_modules/expo-speech-recognition/ios/SpeechRecognitionOptions.swift b/node_modules/expo-speech-recognition/ios/SpeechRecognitionOptions.swift
+index d38a050..5b16d85 100644
+--- a/node_modules/expo-speech-recognition/ios/SpeechRecognitionOptions.swift
++++ b/node_modules/expo-speech-recognition/ios/SpeechRecognitionOptions.swift
+@@ -40,6 +40,15 @@ struct SpeechRecognitionOptions: Record {
+ 
+   @Field
+   var iosVoiceProcessingEnabled: Bool? = false
++
++  // Bluetooth マイク選択用（autopl パッチ #67）
++  // expo-speech-recognition の setupAudioSession() と AVAudioEngine() の間で
++  // setPreferredInput を呼ぶために使用する
++  @Field
++  var iosPreferredInputUID: String? = nil
++
++  @Field
++  var iosPreferredInputName: String? = nil
+ }
+ 
+ struct VolumeChangeEventOptions: Record {

--- a/src/hooks/useAudioDeviceRoute.ts
+++ b/src/hooks/useAudioDeviceRoute.ts
@@ -88,6 +88,17 @@ export const useAudioDeviceRoute = () => {
     return () => subscription.remove()
   }, [refreshDevices])
 
+  // オーディオルート変更時にデバイス一覧を再スキャン（#67）
+  // TrackPlayer の再生開始、Bluetooth デバイスの接続/切断で発火する
+  useEffect(() => {
+    const subscription = AudioRoute.addRouteChangeListener(() => {
+      refreshDevices()
+    })
+    return () => {
+      subscription?.remove()
+    }
+  }, [refreshDevices])
+
   const selectInput = useCallback(
     async (uid: string) => {
       try {

--- a/src/hooks/useVoiceRecognition.ts
+++ b/src/hooks/useVoiceRecognition.ts
@@ -169,7 +169,12 @@ export const useVoiceRecognition = (
         requiresOnDeviceRecognition: !isOnlineRef.current,
         contextualStrings: [wakeWord, ...Object.values(commands)],
         iosCategory,
-      })
+        // expo-speech-recognition パッチ (#67):
+        // setupAudioSession() と AVAudioEngine() の間で setPreferredInput を呼ぶ
+        // これにより setCategory() が preferredInput をリセットしても再設定される
+        iosPreferredInputUID: preferredInputUID ?? undefined,
+        iosPreferredInputName: preferredInputName ?? undefined,
+      } as Parameters<typeof ExpoSpeechRecognitionModule.start>[0])
     } catch (error) {
       console.error('[useVoiceRecognition] startRecognition failed:', error)
     }


### PR DESCRIPTION
## Summary

前回のPR #68 で `.defaultToSpeaker` 除外を行ったが、実機テストで以下が未解決だった:

1. **Bluetoothイヤホンのマイクが依然として使用されない**
2. **音楽再生開始時にデバイスピッカーが消える**
3. **切断したBluetoothデバイスがピッカーに残り続ける**

### 根本原因の発見

`expo-speech-recognition` の内部で `setupAudioSession()` → `AVAudioEngine()` が連続実行される。
**`setCategory()` は同一パラメータであっても `preferredInput` をリセットする可能性がある**（iOS 16+）。
そのため `prepareSessionForRecognition` で事前に設定した `setPreferredInput` が無効化され、
`AVAudioEngine.inputNode` が内蔵マイクをキャプチャしていた。

### 修正内容

- **expo-speech-recognition を patch-package でパッチ**: `setupAudioSession()` と `AVAudioEngine()` の間で `setPreferredInput` を再適用。`restartAudioEngineForRouteChange()` でも同様に再適用。
- **AudioRouteModule に `onAudioRouteChange` イベントを追加**: TrackPlayer 再生開始や Bluetooth 接続/切断で JS 層にルート変更を通知し、デバイスリストを自動更新
- **A2DP キャッシュのクリーンアップ**: `oldDeviceUnavailable` 時にキャッシュから削除

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `patches/expo-speech-recognition+3.1.1.patch` | **新規** パッチファイル |
| `modules/audio-route/ios/AudioRouteModule.swift` | ルート変更イベント発行、A2DPキャッシュクリーンアップ |
| `modules/audio-route/index.ts` | EventEmitter・addRouteChangeListener 追加 |
| `src/hooks/useVoiceRecognition.ts` | iosPreferredInputUID/Name を start() に渡す |
| `src/hooks/useAudioDeviceRoute.ts` | onAudioRouteChange イベント購読 |
| `docs/ios-audio-session-behavior.md` | セクション12,13 更新 |
| `package.json` | postinstall: patch-package 追加 |

## ビルド

**ネイティブビルドが必要**

```bash
npm install  # patch-package が postinstall で実行される
npx expo prebuild --clean
npx expo run:ios --device
```

## Test plan

- [ ] Bluetoothイヤホン接続 → ピッカーでマイクに選択 → 音声認識がイヤホンマイクを使用すること
- [ ] 音楽再生開始後もデバイスピッカーが表示され、正しいデバイスリストが表示されること
- [ ] Bluetoothスピーカー切断後、ピッカーから消えること
- [ ] Bluetoothスピーカー接続中、スピーカーピッカーに表示されること
- [ ] Bluetooth未接続時、内蔵スピーカーから音声出力されること
- [ ] 設定画面を開いただけで音楽が途切れないこと

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)